### PR TITLE
Bugfix

### DIFF
--- a/python/metashape_workflow.py
+++ b/python/metashape_workflow.py
@@ -18,11 +18,11 @@ manual_config_file = "/storage/forestuav/configs/set31/cfg_paramset31_55.yml" #"
 try:  # running interactively
     from python import metashape_workflow_functions as meta
     from python import read_yaml
-    config_file = manual_config_file
+    config_file = sys.argv[1]
 except:  # running from command line
     import metashape_workflow_functions as meta
     import read_yaml
-    config_file = sys.argv[1]
+    config_file = manual_config_file
 
 ## Parse the config file
 cfg = read_yaml.read_yaml(config_file)


### PR DESCRIPTION
Ran into issues with the current setup under Win10 + Spyder/Jupyter Lab environments in Anaconda Python 3.7.
config_file = manual_config_file moved to except: (and config_file = sys.argv[1] to try:) to allow for command-line execution that was otherwise not possible. 