### PR TITLE
Incorporate incremental alignment in a single workflow run via config

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -14,6 +14,15 @@ photo_path: "/example/path/to/photo/folder"
 separate_calibration_per_path: True # If True, each photo path (i.e. each element in the list supplied to 'photo_path' above) will be calibrated independently. Regardless whether True or False, separate camera *models* are calibrated separately; if True, identical camera *models* are calibrated separately if they are provided as separate paths. This addresses the case where two different instances of the same camera model are used in the same project. Note that when True, the logic for assigning separate calibration to each path assumes that the same camera is used for all photos in the path.
 multispectral: False # Is this a multispectral photo set? If RGB, set to False.
 
+# The path to a secondary directory of flight photos, which are only aligned to the project *after*
+# all the other processing is done. This is useful if you want to use secondary photos for multiview
+# analyses (e.g., species ID) without affecting the photogrammetry. Note that the secondary photos
+# are processed in the same way as the primary (e.g., same resolution, same procedure regarding
+# separate calibration per path) and that align_photos:reset_alignment must be False and
+# align_photos:keep_keypoints must be True. If there are no secondary photos to add, set to an empty
+# string ("").
+photo_path_secondary: "/example/path/to/secondary/photo/folder"
+
 # Path for exports (e.g., points, DSM, orthomosaic) and processing log. Will be created if does not exist.
 output_path: "/example/output/path"
 

--- a/python/metashape_workflow.py
+++ b/python/metashape_workflow.py
@@ -74,6 +74,9 @@ if cfg["buildModel"]["enabled"]:
 # For this step, the check for whether it is enabled in the config happens inside the function, because there are two steps (DEM and ortho), each of which can be enabled independently
 meta.build_dem_orthomosaic(doc, log, run_id, cfg)
 
+if cfg["photo_path_secondary"] != "":
+    meta.add_and_align_secondary_photos(doc, log, run_id, cfg)
+
 meta.export_report(doc, run_id, cfg)
 
 meta.finish_run(log, config_file)

--- a/python/metashape_workflow.py
+++ b/python/metashape_workflow.py
@@ -75,7 +75,7 @@ if cfg["buildModel"]["enabled"]:
 meta.build_dem_orthomosaic(doc, log, run_id, cfg)
 
 if cfg["photo_path_secondary"] != "":
-    meta.add_and_align_secondary_photos(doc, log, run_id, cfg)
+    meta.add_align_secondary_photos(doc, log, run_id, cfg)
 
 meta.export_report(doc, run_id, cfg)
 

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -927,7 +927,7 @@ def build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending, from_mesh 
 
     return True
     
-def add_and_align_secondary_photos(doc, log_file, run_id, cfg):
+def add_align_secondary_photos(doc, log_file, run_id, cfg):
     """
     Add and align a second set of photos, to be aligned only. The main use case for this currently
     is to be able to build all photogrammetry products from the primary set of photos (e.g., a nadir
@@ -956,9 +956,6 @@ def add_and_align_secondary_photos(doc, log_file, run_id, cfg):
     with open(log_file, "a") as file:
         file.write(sep.join(["Add secondary photos", time2]) + "\n")
         
-    # # get a beginning time stamp for the next step
-    # timer2a = time.time()
-    
     # Save the transform matrix
     matrix_saved = doc.chunk.transform.matrix
 
@@ -969,16 +966,6 @@ def add_and_align_secondary_photos(doc, log_file, run_id, cfg):
     
     # Restore the saved transform matrix
     doc.chunk.transform.matrix = matrix_saved
-
-    # # get an ending time stamp for the previous step
-    # timer2b = time.time()
-
-    # # calculate difference between end and start time to 1 decimal place
-    # time2 = diff_time(timer2b, timer2a)
-
-    # # record results to file
-    # with open(log_file, "a") as file:
-    #     file.write(sep.join(["Align secondary photos", time2]) + "\n")    
 
     doc.save()
 

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -956,8 +956,8 @@ def add_and_align_secondary_photos(doc, log_file, run_id, cfg):
     with open(log_file, "a") as file:
         file.write(sep.join(["Add secondary photos", time2]) + "\n")
         
-    # get a beginning time stamp for the next step
-    timer2a = time.time()
+    # # get a beginning time stamp for the next step
+    # timer2a = time.time()
     
     # Save the transform matrix
     matrix_saved = doc.chunk.transform.matrix
@@ -965,20 +965,20 @@ def add_and_align_secondary_photos(doc, log_file, run_id, cfg):
     # Align the secondary photos (really, align all photos, but only the secondary photos will be
     # affected because Metashape only matches and aligns photos that were not already
     # matched/aligned, assuming keep_keypoints and reset_alignment were set as required).
-    align_photos(doc, log, run_id, cfg)
+    align_photos(doc, log_file, run_id, cfg)
     
     # Restore the saved transform matrix
     doc.chunk.transform.matrix = matrix_saved
 
-    # get an ending time stamp for the previous step
-    timer2b = time.time()
+    # # get an ending time stamp for the previous step
+    # timer2b = time.time()
 
-    # calculate difference between end and start time to 1 decimal place
-    time2 = diff_time(timer2b, timer2a)
+    # # calculate difference between end and start time to 1 decimal place
+    # time2 = diff_time(timer2b, timer2a)
 
-    # record results to file
-    with open(log_file, "a") as file:
-        file.write(sep.join(["Align secondary photos", time2]) + "\n")    
+    # # record results to file
+    # with open(log_file, "a") as file:
+    #     file.write(sep.join(["Align secondary photos", time2]) + "\n")    
 
     doc.save()
 


### PR DESCRIPTION
In the config, you specify a secondary set of images to align (only) after all other photogrammetry and exports are done.