### PR TITLE
Make GCPs work with absolute image paths as the image labels

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -50,11 +50,6 @@ gpu_multiplier: 2
 ## Refer to Metashape documentation for full parameter definitions: https://www.agisoft.com/pdf/metashape_python_api_1_5_0.pdf
 ## Parameter names here generally follow the parameter names of the Metashape functions.
 
-### Whether to use image EXIF RTK flags to make image geospatial accuracy more precise. If enabled but photos don't have RTK data, will treat them as regular photos and use the nofix accuracy.
-use_rtk: False
-fix_accuracy: 3 # Accuracy to set for photos that have a RTK fix, in units of the CRS
-nofix_accuracy: 25 # Accuracy to set for photos that have no fix, in units of the CRS
-
 # Should the photos at the path(s) listed above be added to the project? Can disable if, for
 # example, you only want to add GCPs (or do additional processing) to an existing project.
 addPhotos: # (Metashape: addPhotos)

--- a/config/base.yml
+++ b/config/base.yml
@@ -11,8 +11,6 @@ load_project: ""
 # or provide a list of paths via the YAML list syntax (e.g., ["/path/to/photo/folder1", "/path/to/photo/folder2"])
 # If there are no photos to add (e.g., this is an existing project that already has photos in it, set to an empty string ("")
 photo_path: "/example/path/to/photo/folder"
-separate_calibration_per_path: True # If True, each photo path (i.e. each element in the list supplied to 'photo_path' above) will be calibrated independently. Regardless whether True or False, separate camera *models* are calibrated separately; if True, identical camera *models* are calibrated separately if they are provided as separate paths. This addresses the case where two different instances of the same camera model are used in the same project. Note that when True, the logic for assigning separate calibration to each path assumes that the same camera is used for all photos in the path.
-multispectral: False # Is this a multispectral photo set? If RGB, set to False.
 
 # The path to a secondary directory of flight photos, which are only aligned to the project *after*
 # all the other processing is done. This is useful if you want to use secondary photos for multiview
@@ -57,13 +55,15 @@ use_rtk: False
 fix_accuracy: 3 # Accuracy to set for photos that have a RTK fix, in units of the CRS
 nofix_accuracy: 25 # Accuracy to set for photos that have no fix, in units of the CRS
 
-# To use GCPs, a 'gcps' folder must exist in the top level photos folder. The contents of the 'gcps' folder are created by the prep_gcps.R script. See readme: https://github.com/ucdavis/metashape
-addGCPs:
-    enabled: False
-    gcp_crs: "EPSG::26910" # CRS EPSG code of GCP coordinates. 26910 (UTM 10 N) is the CRS of the sample RGB photoset.
-    marker_location_accuracy: 0.1 # Accuracy of GCPs real-world coordinates, in meters.
-    marker_projection_accuracy: 8 # Accuracy of the identified locations of the GCPs within the images, in pixels.
-    optimize_w_gcps_only: True # Optimize alignment using GCPs only: required for GCP locations to take precedence over photo GPS data. Disabling it makes GCPs essentially irrelevant.
+# Should the photos at the path(s) listed above be added to the project? Can disable if, for
+# example, you only want to add GCPs (or do additional processing) to an existing project.
+addPhotos: # (Metashape: addPhotos)
+  enabled: True # This applies tot he main photos specified in photo_path above. Secondary photos are always added and aligned if a path (or paths) is provided.
+  separate_calibration_per_path: False # If True, each photo path (i.e. each element in the list supplied to 'photo_path' above) will be calibrated independently. Regardless whether True or False, separate camera *models* are calibrated separately; if True, identical camera *models* are calibrated separately if they are provided as separate paths. This addresses the case where two different instances of the same camera model are used in the same project. Note that when True, the logic for assigning separate calibration to each path assumes that the same camera is used for all photos in the path.
+  multispectral: False # Is this a multispectral photo set? If RGB, set to False.
+  use_rtk: False # Whether to use image EXIF RTK flags to make image geospatial accuracy more precise. If enabled but photos don't have RTK data, will treat them as regular photos and use the nofix accuracy.
+  fix_accuracy: 3 # Accuracy to set for photos that have a RTK fix, in units of the CRS
+  nofix_accuracy: 25 # Accuracy to set for photos that have no fix, in units of the CRS
 
 calibrateReflectance: # (Metahsape: calibrateReflectance)
     enabled: False
@@ -81,6 +81,16 @@ alignPhotos: # (Metashape: matchPhotos, alignCameras, (optionally) exportCameras
     reference_preselection: True # When matching photos, use the camera location data to narrow down the potential neighbors to pair?
     reference_preselection_mode: Metashape.ReferencePreselectionSource # When matching photos, use the camera location data to narrow down the potential neighbors to pair?
     export: True # Export the camera locations
+
+# To use GCPs, a 'gcps' folder must exist in the root of the photo folder provided in photo_path
+# above (or the first folder, if a list is passed). The contents of the 'gcps' folder are created by
+# the prep_gcps.R script. See readme: https://github.com/ucdavis/metashape
+addGCPs:
+    enabled: False
+    gcp_crs: "EPSG::26910" # CRS EPSG code of GCP coordinates. 26910 (UTM 10 N) is the CRS of the sample RGB photoset.
+    marker_location_accuracy: 0.1 # Accuracy of GCPs real-world coordinates, in meters.
+    marker_projection_accuracy: 8 # Accuracy of the identified locations of the GCPs within the images, in pixels.
+    optimize_w_gcps_only: True # Optimize alignment using GCPs only: required for GCP locations to take precedence over photo GPS data. Disabling it makes GCPs essentially irrelevant.
 
 filterPointsUSGS:
     enabled: False

--- a/python/metashape_workflow.py
+++ b/python/metashape_workflow.py
@@ -36,7 +36,7 @@ doc, log, run_id = meta.project_setup(cfg, config_file)
 
 meta.enable_and_log_gpu(log, cfg)
 
-if cfg["photo_path"] != "":  # only add photos if there is a photo directory listed
+if (cfg["photo_path"] != "") and (cfg["addPhotos"]["enabled"]):  # only add photos if there is a photo directory listed
     meta.add_photos(doc, cfg)
 
 if cfg["calibrateReflectance"]["enabled"]:

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -352,7 +352,7 @@ def add_gcps(doc, cfg):
         )
 
     ## Assign real-world coordinates to each GCP
-    path = os.path.join(cfg["photo_path"], "gcps", "prepared", "gcp_table.csv")
+    path = os.path.join(photo_path, "gcps", "prepared", "gcp_table.csv")
 
     file = open(path)
     content = file.read().splitlines()

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -213,7 +213,7 @@ def add_photos(doc, cfg, secondary = False):
         ]
 
         ## Add them
-        if cfg["multispectral"]:
+        if cfg["addPhotos"]["multispectral"]:
             doc.chunk.addPhotos(photo_files, layout=Metashape.MultiplaneLayout, group = grp)
         else:
             doc.chunk.addPhotos(photo_files, group = grp)
@@ -223,7 +223,7 @@ def add_photos(doc, cfg, secondary = False):
         path = camera.photo.path
         camera.label = path
     
-    if cfg["separate_calibration_per_path"] :
+    if cfg["addPhotos"]["separate_calibration_per_path"] :
         # Assign a different (new) sensor (i.e. independent calibration) to each group of photos
         for grp in doc.chunk.camera_groups:
 
@@ -244,29 +244,29 @@ def add_photos(doc, cfg, secondary = False):
         doc.chunk.remove(doc.chunk.sensors[0])
 
     ## If specified, change the accuracy of the cameras to match the RTK flag (RTK fix if flag = 50, otherwise no fix
-    if cfg["use_rtk"]:
+    if cfg["addPhotos"]["use_rtk"]:
         for cam in doc.chunk.cameras:
             rtkflag = cam.photo.meta["DJI/RtkFlag"]
             if rtkflag == "50":
                 cam.reference.location_accuracy = Metashape.Vector(
-                    [cfg["fix_accuracy"], cfg["fix_accuracy"], cfg["fix_accuracy"]]
+                    [cfg["addPhotos"]["fix_accuracy"], cfg["addPhotos"]["fix_accuracy"], cfg["addPhotos"]["fix_accuracy"]]
                 )
                 cam.reference.accuracy = Metashape.Vector(
-                    [cfg["fix_accuracy"], cfg["fix_accuracy"], cfg["fix_accuracy"]]
+                    [cfg["addPhotos"]["fix_accuracy"], cfg["addPhotos"]["fix_accuracy"], cfg["addPhotos"]["fix_accuracy"]]
                 )
             else:
                 cam.reference.location_accuracy = Metashape.Vector(
                     [
-                        cfg["nofix_accuracy"],
-                        cfg["nofix_accuracy"],
-                        cfg["nofix_accuracy"],
+                        cfg["addPhotos"]["nofix_accuracy"],
+                        cfg["addPhotos"]["nofix_accuracy"],
+                        cfg["addPhotos"]["nofix_accuracy"],
                     ]
                 )
                 cam.reference.accuracy = Metashape.Vector(
                     [
-                        cfg["nofix_accuracy"],
-                        cfg["nofix_accuracy"],
-                        cfg["nofix_accuracy"],
+                        cfg["addPhotos"]["nofix_accuracy"],
+                        cfg["addPhotos"]["nofix_accuracy"],
+                        cfg["addPhotos"]["nofix_accuracy"],
                     ]
                 )
 
@@ -300,9 +300,30 @@ def add_gcps(doc, cfg):
     Add GCPs (GCP coordinates and the locations of GCPs in individual photos.
     See the helper script (and the comments therein) for details on how to prepare the data needed by this function: R/prep_gcps.R
     """
+    
+    # Determine the location of the GCPs file, which is also the base path to prepend to the GCP
+    # camera label (relative to what's specified in the GCPs file, which is a relative path), to
+    # make it into an absolute path to match the label of the camera in the Metashape. Note the
+    # difference between the two camera labels: one is the camera label specified in the GCPs file
+    # (relative path), and one is the camera label in the Metashape (absolute). Currently, this
+    # assumes that all of the GCPs apply to the first provided folder of cameras (i.e., the only
+    # folder provided, or the first folder provided if multiple are provided) -- and that this is
+    # the folder containing the GCP definition file. TODO: Tolerate GCPs split across multiple
+    # folders of input images:
+    # https://github.com/open-forest-observatory/automate-metashape-2/issues/49.
+    
+    photo_paths = cfg["photo_path"]
+    
+    # If it's a single string (i.e. one directory), make it a list of one string so we can take the
+    # first element using the same operation we would use on a list of strings
+    if (isinstance(photo_paths, str)):
+        photo_paths = [photo_paths]
+    
+    # Take the first folder and assume it's the one with the GCPs file    
+    photo_path = photo_paths[0]
 
     ## Tag specific pixels in specific images where GCPs are located
-    path = os.path.join(cfg["photo_path"], "gcps", "prepared", "gcp_imagecoords_table.csv")
+    path = os.path.join(photo_path, "gcps", "prepared", "gcp_imagecoords_table.csv")
     file = open(path)
     content = file.read().splitlines()
 
@@ -317,6 +338,9 @@ def add_gcps(doc, cfg):
         if not marker:
             marker = doc.chunk.addMarker()
             marker.label = marker_label
+            
+        # Prepend the image path to the GCP's camera label to make it an absolute path
+        camera_label = os.path.join(photo_path, camera_label)
 
         camera = get_camera(doc.chunk, camera_label)
         if not camera:


### PR DESCRIPTION
This addresses the fact that in the GCP file, image identities are specified as relative paths (so that the folder of images with the GCP file is portable). This prepends the relative image paths with the image folder so that the GCP-referenced images can be linked to the meatshape images, which are now specified using absolute paths.

Currently, this assumes that all of the GCPs apply to the first provided folder of cameras (i.e., the only folder provided, or the first folder provided if multiple are provided) -- and that this is the folder containing the GCP definition file. TODO: Tolerate GCPs split across multiple folders of input images: https://github.com/open-forest-observatory/automate-metashape-2/issues/49.