### PR TITLE
Add black and isort for auto style formatting

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,40 @@
+name: Black Linter
+
+# This allows Black be called from the isort workflow
+on:
+  workflow_call:
+
+jobs:
+  black-linter:
+    name: Run Black
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Determine Branch Name
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "BRANCH_NAME=${{ github.head_ref }}" >> $GITHUB_ENV
+          else
+            BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+            echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.BRANCH_NAME }}
+
+      - name: Pull latest changes
+        run: git pull origin ${{ env.BRANCH_NAME }}
+
+      - name: Run Black formatter
+        uses: psf/black@stable
+        with:
+          options: "--verbose"
+          src: "."
+          jupyter: true
+
+      - name: Push changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Apply black formatting changes

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -1,0 +1,45 @@
+name: Code Formatter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  isort:
+    name: Run Isort
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Determine Branch Name
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "BRANCH_NAME=${{ github.head_ref }}" >> $GITHUB_ENV
+          else
+            BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+            echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.BRANCH_NAME }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Run Isort
+        run: pip install isort==5.13.2 && isort .
+
+      - name: Push changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Apply isort formatting changes
+
+  # Ensure Black runs after Isort has completed
+  black:
+    needs: isort
+    uses: ./.github/workflows/black.yml

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -1,6 +1,6 @@
 name: Code Formatter
 
-# Add `pull_request:` to apply on active PRs 
+# Add 'pull_request:' beneath 'on:' to apply on active PRs
 on:
   push:
     branches:
@@ -11,6 +11,7 @@ jobs:
     name: Run Isort
     runs-on: ubuntu-latest
 
+    # Redundant to determine branch name since workflow only runs on main, but will be useful if we also want the workflow to run PRs
     steps:
       - name: Determine Branch Name
         run: |

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -1,10 +1,10 @@
 name: Code Formatter
 
+# Add `pull_request:` to apply on active PRs 
 on:
   push:
     branches:
       - main
-  pull_request:
 
 jobs:
   isort:

--- a/prior-versions/metashape_v1.6-1.8/python/metashape_workflow.py
+++ b/prior-versions/metashape_v1.6-1.8/python/metashape_workflow.py
@@ -22,7 +22,7 @@ except:  # running from command line (in linux) or interactively (windows)
     import metashape_workflow_functions as meta
     import read_yaml
 
-if(sys.stdin.isatty()):
+if sys.stdin.isatty():
     config_file = sys.argv[1]
 else:
     config_file = manual_config_file

--- a/prior-versions/metashape_v1.6-1.8/python/metashape_workflow_functions.py
+++ b/prior-versions/metashape_v1.6-1.8/python/metashape_workflow_functions.py
@@ -9,6 +9,7 @@ import glob
 import os
 import platform
 import re
+
 # import the fuctionality we need to make time stamps to measure performance
 import time
 
@@ -23,19 +24,22 @@ import yaml
 # TODO: Consider moving log to json/yaml formatting using a dict
 sep = "; "
 
+
 def stamp_time():
-    '''
+    """
     Format the timestamps as needed
-    '''
-    stamp = datetime.datetime.now().strftime('%Y%m%dT%H%M')
+    """
+    stamp = datetime.datetime.now().strftime("%Y%m%dT%H%M")
     return stamp
 
+
 def diff_time(t2, t1):
-    '''
+    """
     Give a end and start time, subtract, and round
-    '''
-    total = str(round(t2-t1, 1))
+    """
+    total = str(round(t2 - t1, 1))
     return total
+
 
 # Used by add_gcps function
 def get_marker(chunk, label):
@@ -43,6 +47,7 @@ def get_marker(chunk, label):
         if marker.label == label:
             return marker
     return None
+
 
 # Used by add_gcps function
 def get_camera(chunk, label):
@@ -52,17 +57,17 @@ def get_camera(chunk, label):
     return None
 
 
-
 #### Functions for each major step in Metashape
 
+
 def project_setup(cfg):
-    '''
+    """
     Create output and project paths, if they don't exist
     Define a project ID based on photoset name and timestamp
     Define a project filename and a log filename
     Create the project
     Start a log file
-    '''
+    """
 
     # Make project directories (necessary even if loading an existing project because this workflow saves a new project based on the old one, leaving the old one intact
     if not os.path.exists(cfg["output_path"]):
@@ -77,19 +82,20 @@ def project_setup(cfg):
 
     ## Project file example to make: "projectID_YYYYMMDDtHHMM-jobID.psx"
     timestamp = stamp_time()
-    run_id = "_".join([run_name,timestamp])
+    run_id = "_".join([run_name, timestamp])
     # TODO: If there is a slurm JobID, append to time (separated with "-", not "_"). This will keep jobs initiated in the same minute distinct
 
-    project_file = os.path.join(cfg["project_path"], '.'.join([run_id, 'psx']) )
-    log_file = os.path.join(cfg["output_path"], '.'.join([run_id+"_log",'txt']) )
+    project_file = os.path.join(cfg["project_path"], ".".join([run_id, "psx"]))
+    log_file = os.path.join(cfg["output_path"], ".".join([run_id + "_log", "txt"]))
 
-
-    '''
+    """
     Create a doc and a chunk
-    '''
+    """
 
     # create a handle to the Metashape object
-    doc = Metashape.Document() #When running via Metashape, can use: doc = Metashape.app.document
+    doc = (
+        Metashape.Document()
+    )  # When running via Metashape, can use: doc = Metashape.app.document
 
     # If specified, open existing project
     if cfg["load_project"] != "":
@@ -103,60 +109,64 @@ def project_setup(cfg):
     # Save doc doc as new project (even if we opened an existing project, save as a separate one so the existing project remains accessible in its original state)
     doc.save(project_file)
 
-
-    '''
+    """
     Log specs except for GPU
-    '''
+    """
 
     # log Metashape version, CPU specs, time, and project location to results file
     # open the results file
     # TODO: records the Slurm values for actual cpus and ram allocated
     # https://slurm.schedmd.com/sbatch.html#lbAI
-    with open(log_file, 'a') as file:
+    with open(log_file, "a") as file:
 
         # write a line with the Metashape version
-        file.write(sep.join(['Project', run_id])+'\n')
-        file.write(sep.join(['Agisoft Metashape Professional Version', Metashape.app.version])+'\n')
+        file.write(sep.join(["Project", run_id]) + "\n")
+        file.write(
+            sep.join(["Agisoft Metashape Professional Version", Metashape.app.version])
+            + "\n"
+        )
         # write a line with the date and time
-        file.write(sep.join(['Processing started', stamp_time()]) +'\n')
+        file.write(sep.join(["Processing started", stamp_time()]) + "\n")
         # write a line with CPU info - if possible, improve the way the CPU info is found / recorded
-        file.write(sep.join(['Node', platform.node()])+'\n')
-        file.write(sep.join(['CPU', platform.processor()]) +'\n')
+        file.write(sep.join(["Node", platform.node()]) + "\n")
+        file.write(sep.join(["CPU", platform.processor()]) + "\n")
         # write two lines with GPU info: count and model names - this takes multiple steps to make it look clean in the end
 
     return doc, log_file, run_id
 
 
-
 def enable_and_log_gpu(log_file, cfg):
-    '''
+    """
     Enables GPU and logs GPU specs
-    '''
+    """
 
     gpustringraw = str(Metashape.app.enumGPUDevices())
     gpucount = gpustringraw.count("name': '")
-    gpustring = ''
+    gpustring = ""
     currentgpu = 1
     while gpucount >= currentgpu:
-        if gpustring != '': gpustring = gpustring+', '
-        gpustring = gpustring+gpustringraw.split("name': '")[currentgpu].split("',")[0]
-        currentgpu = currentgpu+1
-    #gpustring = gpustringraw.split("name': '")[1].split("',")[0]
+        if gpustring != "":
+            gpustring = gpustring + ", "
+        gpustring = (
+            gpustring + gpustringraw.split("name': '")[currentgpu].split("',")[0]
+        )
+        currentgpu = currentgpu + 1
+    # gpustring = gpustringraw.split("name': '")[1].split("',")[0]
     gpu_mask = Metashape.app.gpu_mask
 
-    with open(log_file, 'a') as file:
-        file.write(sep.join(['Number of GPUs Found', str(gpucount)]) +'\n')
-        file.write(sep.join(['GPU Model', gpustring])+'\n')
-        file.write(sep.join(['GPU Mask', str(gpu_mask)])+'\n')
+    with open(log_file, "a") as file:
+        file.write(sep.join(["Number of GPUs Found", str(gpucount)]) + "\n")
+        file.write(sep.join(["GPU Model", gpustring]) + "\n")
+        file.write(sep.join(["GPU Mask", str(gpu_mask)]) + "\n")
 
         # If a GPU exists but is not enabled, enable the 1st one
         if (gpucount > 0) and (gpu_mask == 0):
             Metashape.app.gpu_mask = 1
             gpu_mask = Metashape.app.gpu_mask
-            file.write(sep.join(['GPU Mask Enabled', str(gpu_mask)])+'\n')
+            file.write(sep.join(["GPU Mask Enabled", str(gpu_mask)]) + "\n")
 
         # This writes down all the GPU devices available
-        #file.write('GPU(s): '+str(Metashape.app.enumGPUDevices())+'\n')
+        # file.write('GPU(s): '+str(Metashape.app.enumGPUDevices())+'\n')
 
     # set Metashape to *not* use the CPU during GPU steps (appears to be standard wisdom)
     Metashape.app.cpu_enable = False
@@ -166,49 +176,73 @@ def enable_and_log_gpu(log_file, cfg):
         Metashape.app.settings.setValue("main/gpu_enable_cuda", "0")
 
     # Set GPU multiplier to value specified (2 is default)
-    Metashape.app.settings.setValue("main/depth_max_gpu_multiplier", cfg["gpu_multiplier"])
+    Metashape.app.settings.setValue(
+        "main/depth_max_gpu_multiplier", cfg["gpu_multiplier"]
+    )
 
     return True
 
 
 def add_photos(doc, cfg):
-    '''
+    """
     Add photos to project and change their labels to include their containing folder
-    '''
+    """
 
     ## Get paths to all the project photos
-    a = glob.iglob(os.path.join(cfg["photo_path"],"**","*.*"), recursive=True)   #(([jJ][pP][gG])|([tT][iI][fF]))
+    a = glob.iglob(
+        os.path.join(cfg["photo_path"], "**", "*.*"), recursive=True
+    )  # (([jJ][pP][gG])|([tT][iI][fF]))
     b = [path for path in a]
-    photo_files = [x for x in b if (re.search("(.tif$)|(.jpg$)|(.TIF$)|(.JPG$)",x) and (not re.search("dem_usgs.tif",x)))]
-
+    photo_files = [
+        x
+        for x in b
+        if (
+            re.search("(.tif$)|(.jpg$)|(.TIF$)|(.JPG$)", x)
+            and (not re.search("dem_usgs.tif", x))
+        )
+    ]
 
     ## Add them
     if cfg["multispectral"]:
-        doc.chunk.addPhotos(photo_files, layout = Metashape.MultiplaneLayout)
+        doc.chunk.addPhotos(photo_files, layout=Metashape.MultiplaneLayout)
     else:
         doc.chunk.addPhotos(photo_files)
-
 
     ## Need to change the label on each camera so that it includes the containing folder(S)
     for camera in doc.chunk.cameras:
         path = camera.photo.path
         # remove the base imagery dir from this string
-        rel_path = path.replace(cfg["photo_path"],"")
+        rel_path = path.replace(cfg["photo_path"], "")
         # if it starts with a '/', remove it
-        newlabel = re.sub("^/","",rel_path)
+        newlabel = re.sub("^/", "", rel_path)
         camera.label = newlabel
 
     ## If specified, change the accuracy of the cameras to match the RTK flag (RTK fix if flag = 50, otherwise no fix
     if cfg["use_rtk"]:
         for cam in doc.chunk.cameras:
-            rtkflag = cam.photo.meta['DJI/RtkFlag']
-            if rtkflag == '50':
-                cam.reference.location_accuracy = Metashape.Vector([cfg["fix_accuracy"],cfg["fix_accuracy"],cfg["fix_accuracy"]])
-                cam.reference.accuracy = Metashape.Vector([cfg["fix_accuracy"],cfg["fix_accuracy"],cfg["fix_accuracy"]])
+            rtkflag = cam.photo.meta["DJI/RtkFlag"]
+            if rtkflag == "50":
+                cam.reference.location_accuracy = Metashape.Vector(
+                    [cfg["fix_accuracy"], cfg["fix_accuracy"], cfg["fix_accuracy"]]
+                )
+                cam.reference.accuracy = Metashape.Vector(
+                    [cfg["fix_accuracy"], cfg["fix_accuracy"], cfg["fix_accuracy"]]
+                )
             else:
-                cam.reference.location_accuracy = Metashape.Vector([cfg["nofix_accuracy"],cfg["nofix_accuracy"],cfg["nofix_accuracy"]])
-                cam.reference.accuracy = Metashape.Vector([cfg["nofix_accuracy"],cfg["nofix_accuracy"],cfg["nofix_accuracy"]])
-
+                cam.reference.location_accuracy = Metashape.Vector(
+                    [
+                        cfg["nofix_accuracy"],
+                        cfg["nofix_accuracy"],
+                        cfg["nofix_accuracy"],
+                    ]
+                )
+                cam.reference.accuracy = Metashape.Vector(
+                    [
+                        cfg["nofix_accuracy"],
+                        cfg["nofix_accuracy"],
+                        cfg["nofix_accuracy"],
+                    ]
+                )
 
     doc.save()
 
@@ -218,31 +252,47 @@ def add_photos(doc, cfg):
 def calibrate_reflectance(doc, cfg):
     # TODO: Handle failure to find panels, or mulitple panel images by returning error to user.
     doc.chunk.locateReflectancePanels()
-    doc.chunk.loadReflectancePanelCalibration(os.path.join(cfg["photo_path"],"calibration",cfg["calibrateReflectance"]["panel_filename"]))
+    doc.chunk.loadReflectancePanelCalibration(
+        os.path.join(
+            cfg["photo_path"],
+            "calibration",
+            cfg["calibrateReflectance"]["panel_filename"],
+        )
+    )
     # doc.chunk.calibrateReflectance(use_reflectance_panels=True,use_sun_sensor=True)
-    doc.chunk.calibrateReflectance(use_reflectance_panels=cfg["calibrateReflectance"]["use_reflectance_panels"],
-                                   use_sun_sensor=cfg["calibrateReflectance"]["use_sun_sensor"])
+    doc.chunk.calibrateReflectance(
+        use_reflectance_panels=cfg["calibrateReflectance"]["use_reflectance_panels"],
+        use_sun_sensor=cfg["calibrateReflectance"]["use_sun_sensor"],
+    )
     doc.save()
 
     return True
 
 
 def add_gcps(doc, cfg):
-    '''
+    """
     Add GCPs (GCP coordinates and the locations of GCPs in individual photos.
     See the helper script (and the comments therein) for details on how to prepare the data needed by this function: R/prep_gcps.R
-    '''
+    """
 
     ## Tag specific pixels in specific images where GCPs are located
-    path = os.path.join(cfg["photo_path"], "gcps", "prepared", "gcp_imagecoords_table.csv")
+    path = os.path.join(
+        cfg["photo_path"], "gcps", "prepared", "gcp_imagecoords_table.csv"
+    )
     file = open(path)
     content = file.read().splitlines()
 
     for line in content:
         marker_label, camera_label, x_proj, y_proj = line.split(",")
-        if marker_label[0] == '"': # if it's in quotes (from saving CSV in Excel), remove quotes
-            marker_label = marker_label[1:-1]  # need to get it out of the two pairs of quotes
-        if camera_label[0] == '"':  # if it's in quotes (from saving CSV in Excel), remove quotes
+        if (
+            marker_label[0] == '"'
+        ):  # if it's in quotes (from saving CSV in Excel), remove quotes
+            marker_label = marker_label[
+                1:-1
+            ]  # need to get it out of the two pairs of quotes
+        if (
+            camera_label[0] == '"'
+        ):  # if it's in quotes (from saving CSV in Excel), remove quotes
             camera_label = camera_label[1:-1]
 
         marker = get_marker(doc.chunk, marker_label)
@@ -255,8 +305,9 @@ def add_gcps(doc, cfg):
             print(camera_label + " camera not found in project")
             continue
 
-        marker.projections[camera] = Metashape.Marker.Projection((float(x_proj), float(y_proj)), True)
-
+        marker.projections[camera] = Metashape.Marker.Projection(
+            (float(x_proj), float(y_proj)), True
+        )
 
     ## Assign real-world coordinates to each GCP
     path = os.path.join(cfg["photo_path"], "gcps", "prepared", "gcp_table.csv")
@@ -266,8 +317,12 @@ def add_gcps(doc, cfg):
 
     for line in content:
         marker_label, world_x, world_y, world_z = line.split(",")
-        if marker_label[0] == '"':  # if it's in quotes (from saving CSV in Excel), remove quotes
-            marker_label = marker_label[1:-1]  # need to get it out of the two pairs of quotes
+        if (
+            marker_label[0] == '"'
+        ):  # if it's in quotes (from saving CSV in Excel), remove quotes
+            marker_label = marker_label[
+                1:-1
+            ]  # need to get it out of the two pairs of quotes
 
         marker = get_marker(doc.chunk, marker_label)
         if not marker:
@@ -275,9 +330,17 @@ def add_gcps(doc, cfg):
             marker.label = marker_label
 
         marker.reference.location = (float(world_x), float(world_y), float(world_z))
-        marker.reference.accuracy = (cfg["addGCPs"]["marker_location_accuracy"], cfg["addGCPs"]["marker_location_accuracy"], cfg["addGCPs"]["marker_location_accuracy"])
+        marker.reference.accuracy = (
+            cfg["addGCPs"]["marker_location_accuracy"],
+            cfg["addGCPs"]["marker_location_accuracy"],
+            cfg["addGCPs"]["marker_location_accuracy"],
+        )
 
-    doc.chunk.marker_location_accuracy = (cfg["addGCPs"]["marker_location_accuracy"],cfg["addGCPs"]["marker_location_accuracy"],cfg["addGCPs"]["marker_location_accuracy"])
+    doc.chunk.marker_location_accuracy = (
+        cfg["addGCPs"]["marker_location_accuracy"],
+        cfg["addGCPs"]["marker_location_accuracy"],
+        cfg["addGCPs"]["marker_location_accuracy"],
+    )
     doc.chunk.marker_projection_accuracy = cfg["addGCPs"]["marker_projection_accuracy"]
 
     doc.save()
@@ -286,9 +349,9 @@ def add_gcps(doc, cfg):
 
 
 def align_photos(doc, log_file, cfg):
-    '''
+    """
     Match photos, align cameras, optimize cameras
-    '''
+    """
 
     #### Align photos
 
@@ -296,12 +359,16 @@ def align_photos(doc, log_file, cfg):
     timer1a = time.time()
 
     # Align cameras
-    doc.chunk.matchPhotos(downscale=cfg["alignPhotos"]["downscale"],
-                          subdivide_task = cfg["subdivide_task"],
-                          keep_keypoints = cfg["alignPhotos"]["keep_keypoints"])
-    doc.chunk.alignCameras(adaptive_fitting=cfg["alignPhotos"]["adaptive_fitting"],
-                           subdivide_task = cfg["subdivide_task"],
-                           reset_alignment = cfg["alignPhotos"]["reset_alignment"])
+    doc.chunk.matchPhotos(
+        downscale=cfg["alignPhotos"]["downscale"],
+        subdivide_task=cfg["subdivide_task"],
+        keep_keypoints=cfg["alignPhotos"]["keep_keypoints"],
+    )
+    doc.chunk.alignCameras(
+        adaptive_fitting=cfg["alignPhotos"]["adaptive_fitting"],
+        subdivide_task=cfg["subdivide_task"],
+        reset_alignment=cfg["alignPhotos"]["reset_alignment"],
+    )
     doc.save()
 
     # get an ending time stamp
@@ -311,16 +378,16 @@ def align_photos(doc, log_file, cfg):
     time1 = diff_time(timer1b, timer1a)
 
     # record results to file
-    with open(log_file, 'a') as file:
-        file.write(sep.join(['Align Photos', time1])+'\n')
+    with open(log_file, "a") as file:
+        file.write(sep.join(["Align Photos", time1]) + "\n")
 
     return True
 
 
 def reset_region(doc):
-    '''
+    """
     Reset the region and make it much larger than the points; necessary because if points go outside the region, they get clipped when saving
-    '''
+    """
 
     doc.chunk.resetRegion()
     region_dims = doc.chunk.region.size
@@ -331,9 +398,9 @@ def reset_region(doc):
 
 
 def optimize_cameras(doc, cfg):
-    '''
+    """
     Optimize cameras
-    '''
+    """
 
     # Disable camera locations as reference if specified in YML
     if cfg["addGCPs"]["enabled"] and cfg["addGCPs"]["optimize_w_gcps_only"]:
@@ -342,7 +409,9 @@ def optimize_cameras(doc, cfg):
             doc.chunk.cameras[i].reference.enabled = False
 
     # Currently only optimizes the default parameters, which is not all possible parameters
-    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
+    doc.chunk.optimizeCameras(
+        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
+    )
     doc.save()
 
     return True
@@ -350,7 +419,9 @@ def optimize_cameras(doc, cfg):
 
 def filter_points_usgs_part1(doc, cfg):
 
-    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
+    doc.chunk.optimizeCameras(
+        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
+    )
 
     rec_thresh_percent = cfg["filterPointsUSGS"]["rec_thresh_percent"]
     rec_thresh_absolute = cfg["filterPointsUSGS"]["rec_thresh_absolute"]
@@ -365,21 +436,29 @@ def filter_points_usgs_part1(doc, cfg):
     values.sort()
     thresh = values[int(len(values) * (1 - rec_thresh_percent / 100))]
     if thresh < rec_thresh_absolute:
-        thresh = rec_thresh_absolute  # don't throw away too many points if they're all good
+        thresh = (
+            rec_thresh_absolute  # don't throw away too many points if they're all good
+        )
     fltr.removePoints(thresh)
 
-    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
+    doc.chunk.optimizeCameras(
+        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
+    )
 
     fltr = Metashape.PointCloud.Filter()
     fltr.init(doc.chunk, Metashape.PointCloud.Filter.ProjectionAccuracy)
     values = fltr.values.copy()
     values.sort()
-    thresh = values[int(len(values) * (1- proj_thresh_percent / 100))]
+    thresh = values[int(len(values) * (1 - proj_thresh_percent / 100))]
     if thresh < proj_thresh_absolute:
-        thresh = proj_thresh_absolute  # don't throw away too many points if they're all good
+        thresh = (
+            proj_thresh_absolute  # don't throw away too many points if they're all good
+        )
     fltr.removePoints(thresh)
 
-    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
+    doc.chunk.optimizeCameras(
+        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
+    )
 
     fltr = Metashape.PointCloud.Filter()
     fltr.init(doc.chunk, Metashape.PointCloud.Filter.ReprojectionError)
@@ -390,14 +469,18 @@ def filter_points_usgs_part1(doc, cfg):
         thresh = reproj_thresh_absolute  # don't throw away too many points if they're all good
     fltr.removePoints(thresh)
 
-    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
+    doc.chunk.optimizeCameras(
+        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
+    )
 
     doc.save()
 
 
 def filter_points_usgs_part2(doc, cfg):
 
-    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
+    doc.chunk.optimizeCameras(
+        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
+    )
 
     reproj_thresh_percent = cfg["filterPointsUSGS"]["reproj_thresh_percent"]
     reproj_thresh_absolute = cfg["filterPointsUSGS"]["reproj_thresh_absolute"]
@@ -411,39 +494,40 @@ def filter_points_usgs_part2(doc, cfg):
         thresh = reproj_thresh_absolute  # don't throw away too many points if they're all good
     fltr.removePoints(thresh)
 
-    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
+    doc.chunk.optimizeCameras(
+        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
+    )
 
     doc.save()
 
 
 def classify_ground_points(doc, log_file, run_id, cfg):
 
-        # get a beginning time stamp for the next step
-        timer_a = time.time()
+    # get a beginning time stamp for the next step
+    timer_a = time.time()
 
-        doc.chunk.dense_cloud.classifyGroundPoints(max_angle=cfg["classifyGroundPoints"]["max_angle"],
-                                                   max_distance=cfg["classifyGroundPoints"]["max_distance"],
-                                                   cell_size=cfg["classifyGroundPoints"]["cell_size"])
-        doc.save()
+    doc.chunk.dense_cloud.classifyGroundPoints(
+        max_angle=cfg["classifyGroundPoints"]["max_angle"],
+        max_distance=cfg["classifyGroundPoints"]["max_distance"],
+        cell_size=cfg["classifyGroundPoints"]["cell_size"],
+    )
+    doc.save()
 
-        # get an ending time stamp for the previous step
-        timer_b = time.time()
+    # get an ending time stamp for the previous step
+    timer_b = time.time()
 
-        # calculate difference between end and start time to 1 decimal place
-        time_tot = diff_time(timer_b, timer_a)
+    # calculate difference between end and start time to 1 decimal place
+    time_tot = diff_time(timer_b, timer_a)
 
-        # record results to file
-        with open(log_file, 'a') as file:
-            file.write(sep.join(['Classify Ground Points', time_tot]) + '\n')
-
-
-
+    # record results to file
+    with open(log_file, "a") as file:
+        file.write(sep.join(["Classify Ground Points", time_tot]) + "\n")
 
 
 def build_dense_cloud(doc, log_file, run_id, cfg):
-    '''
+    """
     Build depth maps and dense cloud
-    '''
+    """
 
     ### Build depth maps
 
@@ -451,11 +535,13 @@ def build_dense_cloud(doc, log_file, run_id, cfg):
     timer2a = time.time()
 
     # build depth maps only instead of also building the dense cloud ##?? what does
-    doc.chunk.buildDepthMaps(downscale=cfg["buildDenseCloud"]["downscale"],
-                             filter_mode=cfg["buildDenseCloud"]["filter_mode"],
-                             reuse_depth=cfg["buildDenseCloud"]["reuse_depth"],
-                             max_neighbors=cfg["buildDenseCloud"]["max_neighbors"],
-                             subdivide_task=cfg["subdivide_task"])
+    doc.chunk.buildDepthMaps(
+        downscale=cfg["buildDenseCloud"]["downscale"],
+        filter_mode=cfg["buildDenseCloud"]["filter_mode"],
+        reuse_depth=cfg["buildDenseCloud"]["reuse_depth"],
+        max_neighbors=cfg["buildDenseCloud"]["max_neighbors"],
+        subdivide_task=cfg["subdivide_task"],
+    )
     doc.save()
 
     # get an ending time stamp for the previous step
@@ -465,8 +551,8 @@ def build_dense_cloud(doc, log_file, run_id, cfg):
     time2 = diff_time(timer2b, timer2a)
 
     # record results to file
-    with open(log_file, 'a') as file:
-        file.write(sep.join(['Build Depth Maps', time2]) + '\n')
+    with open(log_file, "a") as file:
+        file.write(sep.join(["Build Depth Maps", time2]) + "\n")
 
     ### Build dense cloud
 
@@ -474,40 +560,43 @@ def build_dense_cloud(doc, log_file, run_id, cfg):
     timer3a = time.time()
 
     # build dense cloud
-    doc.chunk.buildDenseCloud(max_neighbors=cfg["buildDenseCloud"]["max_neighbors"],
-                              keep_depth = cfg["buildDenseCloud"]["keep_depth"],
-                              subdivide_task = cfg["subdivide_task"],
-                              point_colors = True)
+    doc.chunk.buildDenseCloud(
+        max_neighbors=cfg["buildDenseCloud"]["max_neighbors"],
+        keep_depth=cfg["buildDenseCloud"]["keep_depth"],
+        subdivide_task=cfg["subdivide_task"],
+        point_colors=True,
+    )
     doc.save()
 
-
-
-	# classify ground points if specified
+    # classify ground points if specified
     if cfg["buildDenseCloud"]["classify_ground_points"]:
-    	classify_ground_points(doc, log_file, run_id, cfg)
-
+        classify_ground_points(doc, log_file, run_id, cfg)
 
     ### Export points
 
     if cfg["buildDenseCloud"]["export"]:
 
-        output_file = os.path.join(cfg["output_path"], run_id + '_points.las')
+        output_file = os.path.join(cfg["output_path"], run_id + "_points.las")
 
         if cfg["buildDenseCloud"]["classes"] == "ALL":
             # call without classes argument (Metashape then defaults to all classes)
-            doc.chunk.exportPoints(path=output_file,
-                                   source_data=Metashape.DenseCloudData,
-                                   format=Metashape.PointsFormatLAS,
-                                   crs=Metashape.CoordinateSystem(cfg["project_crs"]),
-                                   subdivide_task=cfg["subdivide_task"])
+            doc.chunk.exportPoints(
+                path=output_file,
+                source_data=Metashape.DenseCloudData,
+                format=Metashape.PointsFormatLAS,
+                crs=Metashape.CoordinateSystem(cfg["project_crs"]),
+                subdivide_task=cfg["subdivide_task"],
+            )
         else:
             # call with classes argument
-            doc.chunk.exportPoints(path=output_file,
-                                   source_data=Metashape.DenseCloudData,
-                                   format=Metashape.PointsFormatLAS,
-                                   crs=Metashape.CoordinateSystem(cfg["project_crs"]),
-                                   clases=cfg["buildDenseCloud"]["classes"],
-                                   subdivide_task=cfg["subdivide_task"])
+            doc.chunk.exportPoints(
+                path=output_file,
+                source_data=Metashape.DenseCloudData,
+                format=Metashape.PointsFormatLAS,
+                crs=Metashape.CoordinateSystem(cfg["project_crs"]),
+                clases=cfg["buildDenseCloud"]["classes"],
+                subdivide_task=cfg["subdivide_task"],
+            )
 
     # get an ending time stamp for the previous step
     timer3b = time.time()
@@ -516,31 +605,29 @@ def build_dense_cloud(doc, log_file, run_id, cfg):
     time3 = diff_time(timer3b, timer3a)
 
     # record results to file
-    with open(log_file, 'a') as file:
-        file.write(sep.join(['Build Dense Cloud', time3])+'\n')
+    with open(log_file, "a") as file:
+        file.write(sep.join(["Build Dense Cloud", time3]) + "\n")
 
     return True
 
 
-
-
 def build_dem(doc, log_file, run_id, cfg):
-    '''
+    """
     Build end export DEM
-    '''
-    
+    """
+
     # classify ground points if specified
     if cfg["buildDem"]["classify_ground_points"]:
-    	classify_ground_points(doc, log_file, run_id, cfg)
+        classify_ground_points(doc, log_file, run_id, cfg)
 
     # get a beginning time stamp for the next step
     timer5a = time.time()
 
-    #prepping params for buildDem
+    # prepping params for buildDem
     projection = Metashape.OrthoProjection()
     projection.crs = Metashape.CoordinateSystem(cfg["project_crs"])
 
-    #prepping params for export
+    # prepping params for export
     compression = Metashape.ImageCompression()
     compression.tiff_big = cfg["buildDem"]["tiff_big"]
     compression.tiff_tiled = cfg["buildDem"]["tiff_tiled"]
@@ -548,30 +635,42 @@ def build_dem(doc, log_file, run_id, cfg):
 
     if (cfg["buildDem"]["type"] == "DSM") | (cfg["buildDem"]["type"] == "both"):
         # call without classes argument (Metashape then defaults to all classes)
-        doc.chunk.buildDem(source_data = Metashape.DenseCloudData,
-                           subdivide_task = cfg["subdivide_task"],
-                           projection = projection)
-        output_file = os.path.join(cfg["output_path"], run_id + '_dsm.tif')
+        doc.chunk.buildDem(
+            source_data=Metashape.DenseCloudData,
+            subdivide_task=cfg["subdivide_task"],
+            projection=projection,
+        )
+        output_file = os.path.join(cfg["output_path"], run_id + "_dsm.tif")
         if cfg["buildDem"]["export"]:
-            doc.chunk.exportRaster(path=output_file,
-                                   projection=projection,
-                                   nodata_value=cfg["buildDem"]["nodata"],
-                                   source_data=Metashape.ElevationData,
-                                   image_compression=compression)
+            doc.chunk.exportRaster(
+                path=output_file,
+                projection=projection,
+                nodata_value=cfg["buildDem"]["nodata"],
+                source_data=Metashape.ElevationData,
+                image_compression=compression,
+            )
     if (cfg["buildDem"]["type"] == "DTM") | (cfg["buildDem"]["type"] == "both"):
         # call with classes argument
-        doc.chunk.buildDem(source_data = Metashape.DenseCloudData,
-                           classes = Metashape.PointClass.Ground,
-                           subdivide_task = cfg["subdivide_task"],
-                           projection = projection)
-        output_file = os.path.join(cfg["output_path"], run_id + '_dtm.tif')
+        doc.chunk.buildDem(
+            source_data=Metashape.DenseCloudData,
+            classes=Metashape.PointClass.Ground,
+            subdivide_task=cfg["subdivide_task"],
+            projection=projection,
+        )
+        output_file = os.path.join(cfg["output_path"], run_id + "_dtm.tif")
         if cfg["buildDem"]["export"]:
-            doc.chunk.exportRaster(path=output_file,
-                                   projection=projection,
-                                   nodata_value=cfg["buildDem"]["nodata"],
-                                   source_data=Metashape.ElevationData,
-                                   image_compression=compression)
-    if (cfg["buildDem"]["type"] != "DTM") & (cfg["buildDem"]["type"] == "both") & (cfg["buildDem"]["type"] == "DSM"):
+            doc.chunk.exportRaster(
+                path=output_file,
+                projection=projection,
+                nodata_value=cfg["buildDem"]["nodata"],
+                source_data=Metashape.ElevationData,
+                image_compression=compression,
+            )
+    if (
+        (cfg["buildDem"]["type"] != "DTM")
+        & (cfg["buildDem"]["type"] == "both")
+        & (cfg["buildDem"]["type"] == "DSM")
+    ):
         raise ValueError("DEM type must be either 'DSM' or 'DTM' or 'both'")
 
     doc.save()
@@ -583,37 +682,41 @@ def build_dem(doc, log_file, run_id, cfg):
     time5 = diff_time(timer5b, timer5a)
 
     # record results to file
-    with open(log_file, 'a') as file:
-        file.write(sep.join(['Build DEM', time5])+'\n')
+    with open(log_file, "a") as file:
+        file.write(sep.join(["Build DEM", time5]) + "\n")
 
     return True
 
 
 def build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending):
-    '''
+    """
     Helper function called by build_orthomosaics. build_export_orthomosaic builds and exports an ortho based on the current elevation data.
     build_orthomosaics sets the current elevation data and calls build_export_orthomosaic (one or more times depending on how many orthomosaics requested)
-    '''
+    """
 
     # get a beginning time stamp for the next step
     timer6a = time.time()
 
-    #prepping params for buildDem
+    # prepping params for buildDem
     projection = Metashape.OrthoProjection()
     projection.crs = Metashape.CoordinateSystem(cfg["project_crs"])
 
-    doc.chunk.buildOrthomosaic(surface_data=Metashape.ElevationData,
-                               blending_mode=cfg["buildOrthomosaic"]["blending"],
-                               fill_holes=cfg["buildOrthomosaic"]["fill_holes"],
-                               refine_seamlines=cfg["buildOrthomosaic"]["refine_seamlines"],
-                               subdivide_task=cfg["subdivide_task"],
-                               projection=projection)
+    doc.chunk.buildOrthomosaic(
+        surface_data=Metashape.ElevationData,
+        blending_mode=cfg["buildOrthomosaic"]["blending"],
+        fill_holes=cfg["buildOrthomosaic"]["fill_holes"],
+        refine_seamlines=cfg["buildOrthomosaic"]["refine_seamlines"],
+        subdivide_task=cfg["subdivide_task"],
+        projection=projection,
+    )
 
     doc.save()
 
     ## Export orthomosaic
     if cfg["buildOrthomosaic"]["export"]:
-        output_file = os.path.join(cfg["output_path"], run_id + '_ortho_' + file_ending + '.tif')
+        output_file = os.path.join(
+            cfg["output_path"], run_id + "_ortho_" + file_ending + ".tif"
+        )
 
         compression = Metashape.ImageCompression()
         compression.tiff_big = cfg["buildOrthomosaic"]["tiff_big"]
@@ -623,11 +726,13 @@ def build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending):
         projection = Metashape.OrthoProjection()
         projection.crs = Metashape.CoordinateSystem(cfg["project_crs"])
 
-        doc.chunk.exportRaster(path=output_file,
-                               projection=projection,
-                               nodata_value=cfg["buildOrthomosaic"]["nodata"],
-                               source_data=Metashape.OrthomosaicData,
-                               image_compression=compression)
+        doc.chunk.exportRaster(
+            path=output_file,
+            projection=projection,
+            nodata_value=cfg["buildOrthomosaic"]["nodata"],
+            source_data=Metashape.OrthomosaicData,
+            image_compression=compression,
+        )
 
     # get an ending time stamp for the previous step
     timer6b = time.time()
@@ -636,16 +741,16 @@ def build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending):
     time6 = diff_time(timer6b, timer6a)
 
     # record results to file
-    with open(log_file, 'a') as file:
-        file.write(sep.join(['Build Orthomosaic', time6]) + '\n')
+    with open(log_file, "a") as file:
+        file.write(sep.join(["Build Orthomosaic", time6]) + "\n")
 
     return True
 
 
 def build_orthomosaics(doc, log_file, run_id, cfg):
-    '''
+    """
     Build orthomosaic. This function just calculates the needed elevation data(s) and then calls build_export_orthomosaic to do the actual building and exporting. It does this multiple times if orthos based on multiple surfaces were requsted
-    '''
+    """
 
     # prep projection for export step below (in case export is enabled)
     projection = Metashape.OrthoProjection()
@@ -659,60 +764,65 @@ def build_orthomosaics(doc, log_file, run_id, cfg):
 
     # Import USGS DEM as surface for orthomosaic if specified
     if cfg["buildOrthomosaic"]["surface"] == "USGS":
-        path = os.path.join(cfg["photo_path"],cfg["buildOrthomosaic"]["usgs_dem_path"])
+        path = os.path.join(cfg["photo_path"], cfg["buildOrthomosaic"]["usgs_dem_path"])
         crs = Metashape.CoordinateSystem(cfg["buildOrthomosaic"]["usgs_dem_crs"])
-        doc.chunk.importRaster(path=path,
-                               crs=crs,
-                               raster_type=Metashape.ElevationData)
-        build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending = "USGS")
+        doc.chunk.importRaster(path=path, crs=crs, raster_type=Metashape.ElevationData)
+        build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending="USGS")
     # Otherwise use Metashape point cloud to build elevation model
     # DTM: use ground points only
-    if (cfg["buildOrthomosaic"]["surface"] == "DTM") | (cfg["buildOrthomosaic"]["surface"] == "DTMandDSM"):
-        doc.chunk.buildDem(source_data = Metashape.DenseCloudData,
-                           classes=Metashape.PointClass.Ground,
-                           subdivide_task=cfg["subdivide_task"],
-                           projection=projection)
-        build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending = "dtm")
+    if (cfg["buildOrthomosaic"]["surface"] == "DTM") | (
+        cfg["buildOrthomosaic"]["surface"] == "DTMandDSM"
+    ):
+        doc.chunk.buildDem(
+            source_data=Metashape.DenseCloudData,
+            classes=Metashape.PointClass.Ground,
+            subdivide_task=cfg["subdivide_task"],
+            projection=projection,
+        )
+        build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending="dtm")
     # DSM: use all point classes
-    if (cfg["buildOrthomosaic"]["surface"] == "DSM") | (cfg["buildOrthomosaic"]["surface"] == "DTMandDSM"):
-        doc.chunk.buildDem(source_data = Metashape.DenseCloudData,
-                           subdivide_task=cfg["subdivide_task"],
-                           projection=projection)
-        build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending = "dsm")
+    if (cfg["buildOrthomosaic"]["surface"] == "DSM") | (
+        cfg["buildOrthomosaic"]["surface"] == "DTMandDSM"
+    ):
+        doc.chunk.buildDem(
+            source_data=Metashape.DenseCloudData,
+            subdivide_task=cfg["subdivide_task"],
+            projection=projection,
+        )
+        build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending="dsm")
 
     return True
 
 
 def export_report(doc, run_id, cfg):
-    '''
+    """
     Export report
-    '''
+    """
 
-    output_file = os.path.join(cfg["output_path"], run_id+'_report.pdf')
+    output_file = os.path.join(cfg["output_path"], run_id + "_report.pdf")
 
-    doc.chunk.exportReport(path = output_file)
+    doc.chunk.exportReport(path=output_file)
 
     return True
 
 
-def finish_run(log_file,config_file):
-    '''
+def finish_run(log_file, config_file):
+    """
     Finish run (i.e., write completed time to log)
-    '''
+    """
 
     # finish local results log and close it for the last time
-    with open(log_file, 'a') as file:
-        file.write(sep.join(['Run Completed', stamp_time()])+'\n')
+    with open(log_file, "a") as file:
+        file.write(sep.join(["Run Completed", stamp_time()]) + "\n")
 
     # open run configuration again. We can't just use the existing cfg file because its objects had already been converted to Metashape objects (they don't write well)
     with open(config_file) as file:
         config_full = yaml.safe_load(file)
 
     # write the run configuration to the log file
-    with open(log_file, 'a') as file:
+    with open(log_file, "a") as file:
         file.write("\n\n### CONFIGURATION ###\n")
-        documents = yaml.dump(config_full,file, default_flow_style=False)
+        documents = yaml.dump(config_full, file, default_flow_style=False)
         file.write("### END CONFIGURATION ###\n")
-
 
     return True

--- a/prior-versions/metashape_v1.6-1.8/python/metashape_workflow_functions.py
+++ b/prior-versions/metashape_v1.6-1.8/python/metashape_workflow_functions.py
@@ -4,18 +4,17 @@
 
 #### Import libraries
 
+import datetime
+import glob
+import os
+import platform
+import re
 # import the fuctionality we need to make time stamps to measure performance
 import time
-import datetime
-import platform
-import os
-import glob
-import re
-import yaml
 
 ### import the Metashape functionality
 import Metashape
-
+import yaml
 
 #### Helper functions and globals
 

--- a/prior-versions/metashape_v1.6-1.8/python/read_yaml.py
+++ b/prior-versions/metashape_v1.6-1.8/python/read_yaml.py
@@ -4,8 +4,8 @@ Created on Mon Oct 21 13:45:15 2019
 @author: Alex Mandel
 """
 
-import yaml
 import Metashape
+import yaml
 
 
 def convert_objects(a_dict):

--- a/prior-versions/metashape_v1.6-1.8/python/read_yaml.py
+++ b/prior-versions/metashape_v1.6-1.8/python/read_yaml.py
@@ -9,24 +9,30 @@ import yaml
 
 
 def convert_objects(a_dict):
-    '''
+    """
     Based on
     https://stackoverflow.com/a/25896596/237354
-    '''
+    """
     for k, v in a_dict.items():
         if not isinstance(v, dict):
             if isinstance(v, str):
                 # TODO look for Metashape.
-                if v and 'Metashape' in v and not ('path' in k) and not ('project' in k):    # allow "path" and "project" keys from YAML to include "Metashape" (e.g., Metashape in the filename)
+                if (
+                    v
+                    and "Metashape" in v
+                    and not ("path" in k)
+                    and not ("project" in k)
+                ):  # allow "path" and "project" keys from YAML to include "Metashape" (e.g., Metashape in the filename)
                     a_dict[k] = eval(v)
             elif isinstance(v, list):
                 # TODO skip if no item have metashape
-                a_dict[k] =  [eval(item) for item in v if("Metashape" in item)]
+                a_dict[k] = [eval(item) for item in v if ("Metashape" in item)]
         else:
             convert_objects(v)
 
+
 def read_yaml(yml_path):
-    with open(yml_path,'r') as ymlfile:
+    with open(yml_path, "r") as ymlfile:
         cfg = yaml.load(ymlfile, Loader=yaml.SafeLoader)
 
     # TODO: wrap in a Try to catch errors
@@ -34,23 +40,24 @@ def read_yaml(yml_path):
 
     return cfg
 
+
 if __name__ == "__main__":
 
     yml_path = "config/example.yml"
     cfg = read_yaml(yml_path)
-    #with open("config/example.yml",'r') as ymlfile:
+    # with open("config/example.yml",'r') as ymlfile:
     #    cfg = yaml.load(ymlfile)
 
-    #catch = convert_objects(cfg)
+    # catch = convert_objects(cfg)
 
     # Get a String value
-    Photo_path = cfg['Photo_path']
+    Photo_path = cfg["Photo_path"]
 
     # Get a True/False
-    GPU_use = cfg['GPU']['GPU_use']
+    GPU_use = cfg["GPU"]["GPU_use"]
 
     # Get a Num
-    GPU_num = cfg['GPU']['GPU_num']
+    GPU_num = cfg["GPU"]["GPU_num"]
 
     # Convert a to a Metashape Object
     accuracy = eval(cfg["matchPhotos"]["accuracy"])

--- a/python/metashape_workflow.py
+++ b/python/metashape_workflow.py
@@ -36,7 +36,9 @@ doc, log, run_id = meta.project_setup(cfg, config_file)
 
 meta.enable_and_log_gpu(log, cfg)
 
-if (cfg["photo_path"] != "") and (cfg["addPhotos"]["enabled"]):  # only add photos if there is a photo directory listed
+if (cfg["photo_path"] != "") and (
+    cfg["addPhotos"]["enabled"]
+):  # only add photos if there is a photo directory listed
     meta.add_photos(doc, cfg)
 
 if cfg["calibrateReflectance"]["enabled"]:

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -9,6 +9,7 @@ import glob
 import os
 import platform
 import re
+
 # import the fuctionality we need to make time stamps to measure performance
 import time
 
@@ -79,8 +80,10 @@ def project_setup(cfg, config_file):
 
     run_name = cfg["run_name"]
 
-    if run_name == "from_config_filename" or run_name ==  "":
-        file_basename = os.path.basename(config_file)  # extracts file base name from path
+    if run_name == "from_config_filename" or run_name == "":
+        file_basename = os.path.basename(
+            config_file
+        )  # extracts file base name from path
         run_name, _ = os.path.splitext(file_basename)  # removes extension
 
     ## Project file example to make: "projectID_YYYYMMDDtHHMM-jobID.psx"
@@ -96,7 +99,9 @@ def project_setup(cfg, config_file):
     """
 
     # create a handle to the Metashape object
-    doc = Metashape.Document()  # When running via Metashape, can use: doc = Metashape.app.document
+    doc = (
+        Metashape.Document()
+    )  # When running via Metashape, can use: doc = Metashape.app.document
 
     # If specified, open existing project
     if cfg["load_project"] != "":
@@ -123,7 +128,8 @@ def project_setup(cfg, config_file):
         # write a line with the Metashape version
         file.write(sep.join(["Project", run_id]) + "\n")
         file.write(
-            sep.join(["Agisoft Metashape Professional Version", Metashape.app.version]) + "\n"
+            sep.join(["Agisoft Metashape Professional Version", Metashape.app.version])
+            + "\n"
         )
         # write a line with the date and time
         file.write(sep.join(["Processing started", stamp_time()]) + "\n")
@@ -147,7 +153,9 @@ def enable_and_log_gpu(log_file, cfg):
     while gpucount >= currentgpu:
         if gpustring != "":
             gpustring = gpustring + ", "
-        gpustring = gpustring + gpustringraw.split("name': '")[currentgpu].split("',")[0]
+        gpustring = (
+            gpustring + gpustringraw.split("name': '")[currentgpu].split("',")[0]
+        )
         currentgpu = currentgpu + 1
     # gpustring = gpustringraw.split("name': '")[1].split("',")[0]
     gpu_mask = Metashape.app.gpu_mask
@@ -174,30 +182,32 @@ def enable_and_log_gpu(log_file, cfg):
         Metashape.app.settings.setValue("main/gpu_enable_cuda", "0")
 
     # Set GPU multiplier to value specified (2 is default)
-    Metashape.app.settings.setValue("main/depth_max_gpu_multiplier", cfg["gpu_multiplier"])
+    Metashape.app.settings.setValue(
+        "main/depth_max_gpu_multiplier", cfg["gpu_multiplier"]
+    )
 
     return True
 
 
-def add_photos(doc, cfg, secondary = False):
+def add_photos(doc, cfg, secondary=False):
     """
     Add photos to project and change their labels to include their containing folder. Secondary: if
     True, this is a secondary set of photos to be aligned only, after all photogrammetry products
     have been produced from the primary set of photos.
     """
-    
-    if (secondary):
+
+    if secondary:
         photo_paths = cfg["photo_path_secondary"]
     else:
         photo_paths = cfg["photo_path"]
-    
+
     # If it's a single string (i.e. one directory), make it a list of one string so we can iterate
     # over it the same as if it were a list of strings
-    if (isinstance(photo_paths, str)):
+    if isinstance(photo_paths, str):
         photo_paths = [photo_paths]
-    
+
     for photo_path in photo_paths:
-        
+
         grp = doc.chunk.addCameraGroup()
 
         ## Get paths to all the project photos
@@ -208,21 +218,26 @@ def add_photos(doc, cfg, secondary = False):
         photo_files = [
             x
             for x in b
-            if (re.search("(.tif$)|(.jpg$)|(.TIF$)|(.JPG$)", x) and (not re.search("dem_usgs.tif", x)))
+            if (
+                re.search("(.tif$)|(.jpg$)|(.TIF$)|(.JPG$)", x)
+                and (not re.search("dem_usgs.tif", x))
+            )
         ]
 
         ## Add them
         if cfg["addPhotos"]["multispectral"]:
-            doc.chunk.addPhotos(photo_files, layout=Metashape.MultiplaneLayout, group = grp)
+            doc.chunk.addPhotos(
+                photo_files, layout=Metashape.MultiplaneLayout, group=grp
+            )
         else:
-            doc.chunk.addPhotos(photo_files, group = grp)
-            
+            doc.chunk.addPhotos(photo_files, group=grp)
+
     ## Need to change the label on each camera so that it includes the containing folder(s)
     for camera in doc.chunk.cameras:
         path = camera.photo.path
         camera.label = path
-    
-    if cfg["addPhotos"]["separate_calibration_per_path"] :
+
+    if cfg["addPhotos"]["separate_calibration_per_path"]:
         # Assign a different (new) sensor (i.e. independent calibration) to each group of photos
         for grp in doc.chunk.camera_groups:
 
@@ -234,11 +249,11 @@ def add_photos(doc, cfg, secondary = False):
 
             doc.chunk.addSensor(doc.chunk.cameras[0].sensor)
             sensor = doc.chunk.sensors[-1]
-            
+
             for cam in doc.chunk.cameras:
                 if cam.group == grp:
                     cam.sensor = sensor
-                    
+
         # Remove the first (deafult) sensor, which should no longer be assigned to any photos
         doc.chunk.remove(doc.chunk.sensors[0])
 
@@ -248,10 +263,18 @@ def add_photos(doc, cfg, secondary = False):
             rtkflag = cam.photo.meta["DJI/RtkFlag"]
             if rtkflag == "50":
                 cam.reference.location_accuracy = Metashape.Vector(
-                    [cfg["addPhotos"]["fix_accuracy"], cfg["addPhotos"]["fix_accuracy"], cfg["addPhotos"]["fix_accuracy"]]
+                    [
+                        cfg["addPhotos"]["fix_accuracy"],
+                        cfg["addPhotos"]["fix_accuracy"],
+                        cfg["addPhotos"]["fix_accuracy"],
+                    ]
                 )
                 cam.reference.accuracy = Metashape.Vector(
-                    [cfg["addPhotos"]["fix_accuracy"], cfg["addPhotos"]["fix_accuracy"], cfg["addPhotos"]["fix_accuracy"]]
+                    [
+                        cfg["addPhotos"]["fix_accuracy"],
+                        cfg["addPhotos"]["fix_accuracy"],
+                        cfg["addPhotos"]["fix_accuracy"],
+                    ]
                 )
             else:
                 cam.reference.location_accuracy = Metashape.Vector(
@@ -299,7 +322,7 @@ def add_gcps(doc, cfg):
     Add GCPs (GCP coordinates and the locations of GCPs in individual photos.
     See the helper script (and the comments therein) for details on how to prepare the data needed by this function: R/prep_gcps.R
     """
-    
+
     # Determine the location of the GCPs file, which is also the base path to prepend to the GCP
     # camera label (relative to what's specified in the GCPs file, which is a relative path), to
     # make it into an absolute path to match the label of the camera in the Metashape. Note the
@@ -310,15 +333,15 @@ def add_gcps(doc, cfg):
     # the folder containing the GCP definition file. TODO: Tolerate GCPs split across multiple
     # folders of input images:
     # https://github.com/open-forest-observatory/automate-metashape-2/issues/49.
-    
+
     photo_paths = cfg["photo_path"]
-    
+
     # If it's a single string (i.e. one directory), make it a list of one string so we can take the
     # first element using the same operation we would use on a list of strings
-    if (isinstance(photo_paths, str)):
+    if isinstance(photo_paths, str):
         photo_paths = [photo_paths]
-    
-    # Take the first folder and assume it's the one with the GCPs file    
+
+    # Take the first folder and assume it's the one with the GCPs file
     photo_path = photo_paths[0]
 
     ## Tag specific pixels in specific images where GCPs are located
@@ -328,16 +351,22 @@ def add_gcps(doc, cfg):
 
     for line in content:
         marker_label, camera_label, x_proj, y_proj = line.split(",")
-        if marker_label[0] == '"':  # if it's in quotes (from saving CSV in Excel), remove quotes
-            marker_label = marker_label[1:-1]  # need to get it out of the two pairs of quotes
-        if camera_label[0] == '"':  # if it's in quotes (from saving CSV in Excel), remove quotes
+        if (
+            marker_label[0] == '"'
+        ):  # if it's in quotes (from saving CSV in Excel), remove quotes
+            marker_label = marker_label[
+                1:-1
+            ]  # need to get it out of the two pairs of quotes
+        if (
+            camera_label[0] == '"'
+        ):  # if it's in quotes (from saving CSV in Excel), remove quotes
             camera_label = camera_label[1:-1]
 
         marker = get_marker(doc.chunk, marker_label)
         if not marker:
             marker = doc.chunk.addMarker()
             marker.label = marker_label
-            
+
         # Prepend the image path to the GCP's camera label to make it an absolute path
         camera_label = os.path.join(photo_path, camera_label)
 
@@ -358,8 +387,12 @@ def add_gcps(doc, cfg):
 
     for line in content:
         marker_label, world_x, world_y, world_z = line.split(",")
-        if marker_label[0] == '"':  # if it's in quotes (from saving CSV in Excel), remove quotes
-            marker_label = marker_label[1:-1]  # need to get it out of the two pairs of quotes
+        if (
+            marker_label[0] == '"'
+        ):  # if it's in quotes (from saving CSV in Excel), remove quotes
+            marker_label = marker_label[
+                1:-1
+            ]  # need to get it out of the two pairs of quotes
 
         marker = get_marker(doc.chunk, marker_label)
         if not marker:
@@ -462,7 +495,9 @@ def optimize_cameras(doc, log_file, run_id, cfg):
             doc.chunk.cameras[i].reference.enabled = False
 
     # Currently only optimizes the default parameters, which is not all possible parameters
-    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
+    doc.chunk.optimizeCameras(
+        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
+    )
 
     # get an ending time stamp
     timer1b = time.time()
@@ -488,7 +523,9 @@ def filter_points_usgs_part1(doc, log_file, cfg):
     # get a beginning time stamp
     timer1a = time.time()
 
-    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
+    doc.chunk.optimizeCameras(
+        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
+    )
 
     rec_thresh_percent = cfg["filterPointsUSGS"]["rec_thresh_percent"]
     rec_thresh_absolute = cfg["filterPointsUSGS"]["rec_thresh_absolute"]
@@ -503,10 +540,14 @@ def filter_points_usgs_part1(doc, log_file, cfg):
     values.sort()
     thresh = values[int(len(values) * (1 - rec_thresh_percent / 100))]
     if thresh < rec_thresh_absolute:
-        thresh = rec_thresh_absolute  # don't throw away too many points if they're all good
+        thresh = (
+            rec_thresh_absolute  # don't throw away too many points if they're all good
+        )
     fltr.removePoints(thresh)
 
-    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
+    doc.chunk.optimizeCameras(
+        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
+    )
 
     fltr = Metashape.TiePoints.Filter()
     fltr.init(doc.chunk, Metashape.TiePoints.Filter.ProjectionAccuracy)
@@ -514,10 +555,14 @@ def filter_points_usgs_part1(doc, log_file, cfg):
     values.sort()
     thresh = values[int(len(values) * (1 - proj_thresh_percent / 100))]
     if thresh < proj_thresh_absolute:
-        thresh = proj_thresh_absolute  # don't throw away too many points if they're all good
+        thresh = (
+            proj_thresh_absolute  # don't throw away too many points if they're all good
+        )
     fltr.removePoints(thresh)
 
-    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
+    doc.chunk.optimizeCameras(
+        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
+    )
 
     fltr = Metashape.TiePoints.Filter()
     fltr.init(doc.chunk, Metashape.TiePoints.Filter.ReprojectionError)
@@ -528,7 +573,9 @@ def filter_points_usgs_part1(doc, log_file, cfg):
         thresh = reproj_thresh_absolute  # don't throw away too many points if they're all good
     fltr.removePoints(thresh)
 
-    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
+    doc.chunk.optimizeCameras(
+        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
+    )
 
     # get an ending time stamp
     timer1b = time.time()
@@ -548,7 +595,9 @@ def filter_points_usgs_part2(doc, log_file, cfg):
     # get a beginning time stamp
     timer1a = time.time()
 
-    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
+    doc.chunk.optimizeCameras(
+        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
+    )
 
     reproj_thresh_percent = cfg["filterPointsUSGS"]["reproj_thresh_percent"]
     reproj_thresh_absolute = cfg["filterPointsUSGS"]["reproj_thresh_absolute"]
@@ -562,7 +611,9 @@ def filter_points_usgs_part2(doc, log_file, cfg):
         thresh = reproj_thresh_absolute  # don't throw away too many points if they're all good
     fltr.removePoints(thresh)
 
-    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
+    doc.chunk.optimizeCameras(
+        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
+    )
 
     # get an ending time stamp
     timer1b = time.time()
@@ -773,7 +824,7 @@ def build_dem_orthomosaic(doc, log_file, run_id, cfg):
     if cfg["buildDem"]["classify_ground_points"]:
         classify_ground_points(doc, log_file, run_id, cfg)
 
-    if (cfg["buildDem"]["enabled"]):
+    if cfg["buildDem"]["enabled"]:
         # prepping params for buildDem
         projection = Metashape.OrthoProjection()
         projection.crs = Metashape.CoordinateSystem(cfg["project_crs"])
@@ -784,7 +835,7 @@ def build_dem_orthomosaic(doc, log_file, run_id, cfg):
         compression.tiff_tiled = cfg["buildDem"]["tiff_tiled"]
         compression.tiff_overviews = cfg["buildDem"]["tiff_overviews"]
 
-        if ("DSM-ptcloud" in cfg["buildDem"]["surface"]):
+        if "DSM-ptcloud" in cfg["buildDem"]["surface"]:
             start_time = time.time()
 
             # call without point classes argument (Metashape then defaults to all classes)
@@ -792,7 +843,7 @@ def build_dem_orthomosaic(doc, log_file, run_id, cfg):
                 source_data=Metashape.PointCloudData,
                 subdivide_task=cfg["subdivide_task"],
                 projection=projection,
-                resolution=cfg["buildDem"]["resolution"]
+                resolution=cfg["buildDem"]["resolution"],
             )
 
             time_taken = diff_time(time.time(), start_time)
@@ -810,9 +861,14 @@ def build_dem_orthomosaic(doc, log_file, run_id, cfg):
                     source_data=Metashape.ElevationData,
                     image_compression=compression,
                 )
-                if cfg["buildOrthomosaic"]["enabled"] and "DSM-ptcloud" in cfg["buildOrthomosaic"]["surface"]:
-                    build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending="dsm-ptcloud")
-        if ("DTM-ptcloud" in cfg["buildDem"]["surface"]):
+                if (
+                    cfg["buildOrthomosaic"]["enabled"]
+                    and "DSM-ptcloud" in cfg["buildOrthomosaic"]["surface"]
+                ):
+                    build_export_orthomosaic(
+                        doc, log_file, run_id, cfg, file_ending="dsm-ptcloud"
+                    )
+        if "DTM-ptcloud" in cfg["buildDem"]["surface"]:
 
             start_time = time.time()
 
@@ -822,7 +878,7 @@ def build_dem_orthomosaic(doc, log_file, run_id, cfg):
                 classes=Metashape.PointClass.Ground,
                 subdivide_task=cfg["subdivide_task"],
                 projection=projection,
-                resolution=cfg["buildDem"]["resolution"]
+                resolution=cfg["buildDem"]["resolution"],
             )
 
             time_taken = diff_time(time.time(), start_time)
@@ -840,10 +896,15 @@ def build_dem_orthomosaic(doc, log_file, run_id, cfg):
                     source_data=Metashape.ElevationData,
                     image_compression=compression,
                 )
-                if cfg["buildOrthomosaic"]["enabled"] and "DTM-ptcloud" in cfg["buildOrthomosaic"]["surface"]:
-                    build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending="dtm-ptcloud")
+                if (
+                    cfg["buildOrthomosaic"]["enabled"]
+                    and "DTM-ptcloud" in cfg["buildOrthomosaic"]["surface"]
+                ):
+                    build_export_orthomosaic(
+                        doc, log_file, run_id, cfg, file_ending="dtm-ptcloud"
+                    )
 
-        if ("DSM-mesh" in cfg["buildDem"]["surface"]):
+        if "DSM-mesh" in cfg["buildDem"]["surface"]:
 
             start_time = time.time()
 
@@ -851,7 +912,7 @@ def build_dem_orthomosaic(doc, log_file, run_id, cfg):
                 source_data=Metashape.ModelData,
                 subdivide_task=cfg["subdivide_task"],
                 projection=projection,
-                resolution=cfg["buildDem"]["resolution"]
+                resolution=cfg["buildDem"]["resolution"],
             )
 
             time_taken = diff_time(time.time(), start_time)
@@ -869,14 +930,24 @@ def build_dem_orthomosaic(doc, log_file, run_id, cfg):
                     source_data=Metashape.ElevationData,
                     image_compression=compression,
                 )
-                if cfg["buildOrthomosaic"]["enabled"] and "DSM-mesh" in cfg["buildOrthomosaic"]["surface"]:
-                    build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending="dsm-mesh")
+                if (
+                    cfg["buildOrthomosaic"]["enabled"]
+                    and "DSM-mesh" in cfg["buildOrthomosaic"]["surface"]
+                ):
+                    build_export_orthomosaic(
+                        doc, log_file, run_id, cfg, file_ending="dsm-mesh"
+                    )
 
     # Building an orthomosaic from the mesh does not require a DEM, so this is done separately, independent of any DEM building
-    if (cfg["buildOrthomosaic"]["enabled"] and "Mesh" in cfg["buildOrthomosaic"]["surface"]):
-        build_export_orthomosaic(doc, log_file, run_id, cfg, from_mesh = True, file_ending="mesh")
-    
-    if(cfg["buildPointCloud"]["remove_after_export"]):
+    if (
+        cfg["buildOrthomosaic"]["enabled"]
+        and "Mesh" in cfg["buildOrthomosaic"]["surface"]
+    ):
+        build_export_orthomosaic(
+            doc, log_file, run_id, cfg, from_mesh=True, file_ending="mesh"
+        )
+
+    if cfg["buildPointCloud"]["remove_after_export"]:
         doc.chunk.remove(doc.chunk.point_clouds)
 
     doc.save()
@@ -884,11 +955,11 @@ def build_dem_orthomosaic(doc, log_file, run_id, cfg):
     return True
 
 
-def build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending, from_mesh = False):
+def build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending, from_mesh=False):
     """
     Helper function called by build_dem_orthomosaic. build_export_orthomosaic builds and exports an ortho based on the current elevation data.
     build_dem_orthomosaic sets the current elevation data and calls build_export_orthomosaic (one or more times depending on how many orthomosaics requested)
-    
+
     Note that we have tried using the 'resolution' parameter of buildOrthomosaic, but it does not have any effect. An orthomosaic built onto a DSM always has a reslution of 1/4 the DSM, and one built onto the mesh has a resolution of ~the GSD.
     """
 
@@ -927,7 +998,9 @@ def build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending, from_mesh 
 
     ## Export orthomosaic
     if cfg["buildOrthomosaic"]["export"]:
-        output_file = os.path.join(cfg["output_path"], run_id + "_ortho_" + file_ending + ".tif")
+        output_file = os.path.join(
+            cfg["output_path"], run_id + "_ortho_" + file_ending + ".tif"
+        )
 
         compression = Metashape.ImageCompression()
         compression.tiff_big = cfg["buildOrthomosaic"]["tiff_big"]
@@ -944,12 +1017,13 @@ def build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending, from_mesh 
             source_data=Metashape.OrthomosaicData,
             image_compression=compression,
         )
-    
+
     if cfg["buildOrthomosaic"]["remove_after_export"]:
         doc.chunk.remove(doc.chunk.orthomosaics)
 
     return True
-    
+
+
 def add_align_secondary_photos(doc, log_file, run_id, cfg):
     """
     Add and align a second set of photos, to be aligned only. The main use case for this currently
@@ -957,17 +1031,19 @@ def add_align_secondary_photos(doc, log_file, run_id, cfg):
     mission), but to also estimate the positions of a secondary set of photos (e.g., oblique photos)
     to use for multiview object detection/classification.
     """
-    
-    if (cfg["alignPhotos"]["reset_alignment"] == True):
-        raise ValueError("For aligning secondary photos, reset_alignment must be False.")
-    if (cfg["alignPhotos"]["keep_keypoints"] == False):
+
+    if cfg["alignPhotos"]["reset_alignment"] == True:
+        raise ValueError(
+            "For aligning secondary photos, reset_alignment must be False."
+        )
+    if cfg["alignPhotos"]["keep_keypoints"] == False:
         raise ValueError("For aligning secondary photos, keep_keypoints must be True.")
 
     # get a beginning time stamp for the next step
     timer2a = time.time()
 
     # Add the secondary photos
-    add_photos(doc, cfg, secondary = True)
+    add_photos(doc, cfg, secondary=True)
 
     # get an ending time stamp for the previous step
     timer2b = time.time()
@@ -978,7 +1054,7 @@ def add_align_secondary_photos(doc, log_file, run_id, cfg):
     # record results to file
     with open(log_file, "a") as file:
         file.write(sep.join(["Add secondary photos", time2]) + "\n")
-        
+
     # Save the transform matrix
     matrix_saved = doc.chunk.transform.matrix
 
@@ -986,7 +1062,7 @@ def add_align_secondary_photos(doc, log_file, run_id, cfg):
     # affected because Metashape only matches and aligns photos that were not already
     # matched/aligned, assuming keep_keypoints and reset_alignment were set as required).
     align_photos(doc, log_file, run_id, cfg)
-    
+
     # Restore the saved transform matrix
     doc.chunk.transform.matrix = matrix_saved
 

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -4,18 +4,17 @@
 
 #### Import libraries
 
+import datetime
+import glob
+import os
+import platform
+import re
 # import the fuctionality we need to make time stamps to measure performance
 import time
-import datetime
-import platform
-import os
-import glob
-import re
-import yaml
 
 ### import the Metashape functionality
 import Metashape
-
+import yaml
 
 #### Helper functions and globals
 

--- a/python/read_yaml.py
+++ b/python/read_yaml.py
@@ -4,8 +4,8 @@ Created on Mon Oct 21 13:45:15 2019
 @author: Alex Mandel
 """
 
-import yaml
 import Metashape
+import yaml
 
 
 def convert_objects(a_dict):

--- a/python/read_yaml.py
+++ b/python/read_yaml.py
@@ -41,7 +41,7 @@ def read_yaml(yml_path):
 
     # TODO: wrap in a Try to catch errors
     convert_objects(cfg)
-    
+
     return cfg
 
 


### PR DESCRIPTION
Isort is used to sort Python imports and black is used to format Python code. These two formatters will run on the code on every push to main and on any branch associated with an active pull request. It will then automatically push these changes to the current branch. If you'd like this behavior to change, please let me know and I can do that. 

The automation since the isort workflow will be triggered on a push to main or an active pull request and after it finishes it will call the black workflow and black will be able to run. The two formatters run sequentially and not in parallel because one of the workflows may change the code and push that code to the current branch. And if the other workflow is also making changes there will be merge conflicts.  

Also, since the workflows run on an active pull request, every time you push to an active pull request it would be nice to pull before working on it again since the formatters may make auto styling changes. Otherwise, merge conflicts can happen.