### PR TITLE
Pull cameras xml export out of align_photos

### DIFF
--- a/config/config-example.yml
+++ b/config/config-example.yml
@@ -66,7 +66,7 @@ calibrateReflectance: # (Metahsape: calibrateReflectance)
     use_reflectance_panels: True
     use_sun_sensor: True
 
-alignPhotos: # (Metashape: matchPhotos, alignCameras, (optionally) exportCameras)
+alignPhotos: # (Metashape: matchPhotos, alignCameras)
     enabled: True
     downscale: 2 # How much to coarsen the photos when searching for tie points. Higher number for blurrier photos or when there are small surfaces that may move between photos (such as leaves). Accepts numbers 2^x (and zero) (https://www.agisoft.com/forum/index.php?topic=11697.0).
     adaptive_fitting: True # Should the camera lens model be fit at the same time as aligning photos?
@@ -75,7 +75,6 @@ alignPhotos: # (Metashape: matchPhotos, alignCameras, (optionally) exportCameras
     generic_preselection: True # When matching photos, use a much-coarsened version of each photo to narrow down the potential neighbors to pair? Works well if the photos have high altitude above the surface and high overlap (e.g. a 120m nadir 90/90 overlap mission), but doesn't work well for low-altitude and/or highly oblique photos (e.g. a 80m 25deg pitch 80/80 overlap mission)
     reference_preselection: True # When matching photos, use the camera location data to narrow down the potential neighbors to pair?
     reference_preselection_mode: Metashape.ReferencePreselectionSource # When matching photos, use the camera location data to narrow down the potential neighbors to pair?
-    export: True # Export the camera locations
 
 # To use GCPs, a 'gcps' folder must exist in the root of the photo folder provided in photo_path
 # above (or the first folder, if a list is passed). The contents of the 'gcps' folder are created by
@@ -100,6 +99,13 @@ optimizeCameras: # (Metashape: optimizeCameras)
     enabled: True
     adaptive_fitting: True # Should the camera lens model be fit at the same time as optimizing photos?
     export: True # Export the camera locations, now updated from the initial alignment
+
+# Should an xml file specifying estimated camera locations (transform matrices) be exported? If
+# enabled, it is exported once after all alignment-related steps (e.g., align, fliter points,
+# optimize cameras) -- even if these steps are disabled -- and then again after aligning the
+# secondary set of locations (if performed), overwriting the first file
+exportCameras: # (Metashape: exportCameras)
+    enabled: True
 
 buildDepthMaps: # (Metashape: buildDepthMaps)
     enabled: True

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -1,7 +1,3 @@
-# Derek Young and Alex Mandel
-# University of California, Davis
-# 2021
-
 #### Import libraries
 import datetime
 import glob
@@ -125,7 +121,7 @@ class MetashapeWorkflow:
         if self.cfg["alignPhotos"]["enabled"]:
             self.align_photos()
             self.reset_region()
-
+        
         if self.cfg["filterPointsUSGS"]["enabled"]:
             self.filter_points_usgs_part1()
             self.reset_region()
@@ -142,6 +138,9 @@ class MetashapeWorkflow:
             self.filter_points_usgs_part2()
             self.reset_region()
 
+        if self.cfg["exportCameras"]["enabled"]:
+            self.export_cameras()
+
         if self.cfg["buildDepthMaps"]["enabled"]:
             self.build_depth_maps()
 
@@ -156,6 +155,9 @@ class MetashapeWorkflow:
 
         if self.cfg["photo_path_secondary"] != "":
             self.add_align_secondary_photos()
+
+            if self.cfg["exportCameras"]["enabled"]:
+                self.export_cameras()
 
         self.export_report()
 
@@ -573,11 +575,7 @@ class MetashapeWorkflow:
         # calculate difference between end and start time to 1 decimal place
         time1 = diff_time(timer1b, timer1a)
 
-        # optionally export
-        if self.cfg["alignPhotos"]["export"]:
-            self.export_cameras()
-
-        # record results to file
+        # record processing time to file
         with open(self.log_file, "a") as file:
             file.write(MetashapeWorkflow.sep.join(["Align Photos", time1]) + "\n")
 
@@ -628,10 +626,6 @@ class MetashapeWorkflow:
             file.write(MetashapeWorkflow.sep.join(["Optimize cameras", time1]) + "\n")
 
         self.doc.save()
-
-        # optionally export, note this would override the export from align_cameras
-        if self.cfg["optimizeCameras"]["export"]:
-            self.export_cameras()
 
         return True
 


### PR DESCRIPTION
It is necessary to make `export_cameras` a top-level step in the workflow (as opposed to a sub-step of `align_photos` as it has been) because it may be necessary to insert a workflow step after aligning photos but before exporting the cameras. A case when such a step is necessary is after aligning a second set of photos to an existing project, because aligning them changes the project's transform matrix (i.e. its georeferencing). However, we want to export the camera poses based on the original transform matrix, which requires inserting a step between `align_photos` and `export_cameras`. Now this is possible with `export_cameras` as top-level step in the workflow.