### PR TITLE
Ensure config file is included in command line

### DIFF
--- a/python/metashape_workflow.py
+++ b/python/metashape_workflow.py
@@ -22,7 +22,7 @@ except:  # running from command line (in linux) or interactively (windows)
 
 if sys.stdin.isatty():
     if len(sys.argv) < 2:
-        print("Usage: python <metashape_workflow.py> <config_file.yml>")
+        print("Usage: python <path/to/metashape_workflow.py> <path/to/config_file.yml>")
         sys.exit(1)
     config_file = sys.argv[1]
 else:

--- a/python/metashape_workflow.py
+++ b/python/metashape_workflow.py
@@ -21,6 +21,9 @@ except:  # running from command line (in linux) or interactively (windows)
     from metashape_workflow_functions import MetashapeWorkflow
 
 if sys.stdin.isatty():
+    if len(sys.argv) < 2:
+        print("Usage: python <metashape_workflow.py> <config_file.yml>")
+        sys.exit(1)
     config_file = sys.argv[1]
 else:
     config_file = manual_config_file


### PR DESCRIPTION
I noticed there is a comment in `metashape_workflow.py` that if not running interactively the config file should be passed as a command line argument. I thought it would be nice to throw a useful error if it wasn't provided so the format of the command line would be more clear to users. 