### PR TITLE
Select config example as default config file

### DIFF
--- a/config/config-base.yml
+++ b/config/config-base.yml
@@ -10,7 +10,7 @@ load_project: ""
 # If there are multiple photo folders, set path to the folder that contains all the photo folders,
 # or provide a list of paths via the YAML list syntax (e.g., ["/path/to/photo/folder1", "/path/to/photo/folder2"])
 # If there are no photos to add (e.g., this is an existing project that already has photos in it, set to an empty string ("")
-photo_path: "/example/path/to/photo/folder"
+photo_path: ""
 
 # The path to a secondary directory of flight photos, which are only aligned to the project *after*
 # all the other processing is done. This is useful if you want to use secondary photos for multiview
@@ -19,17 +19,17 @@ photo_path: "/example/path/to/photo/folder"
 # separate calibration per path) and that align_photos:reset_alignment must be False and
 # align_photos:keep_keypoints must be True. If there are no secondary photos to add, set to an empty
 # string ("").
-photo_path_secondary: "/example/path/to/secondary/photo/folder"
+photo_path_secondary: ""
 
 # Path for exports (e.g., points, DSM, orthomosaic) and processing log. Will be created if does not exist.
-output_path: "/example/output/path"
+output_path: ""
 
 # Path to save Metashape project file (.psx). Will be created if does not exist
-project_path: "/example/project/path"
+project_path: ""
 
 # The identifier for the run. Will be used in naming output files. Recommended to include a photoset name and processing parameter set name.
 # Optionally, set it to an empty string ("") to use the config file name (minus extension) as the run name
-run_name: "example-run-001"
+run_name: ""
 
 # CRS EPSG code that project outputs should be in (projection should be in meter units and intended for the project area)
 project_crs: "EPSG::26910" # 26910 is UTM 10N

--- a/python/metashape_workflow.py
+++ b/python/metashape_workflow.py
@@ -7,11 +7,13 @@
 
 import argparse
 import sys
+from pathlib import Path
 
 # ---- If this is a first run from the standalone python module, need to copy the license file from the full metashape install: from python import metashape_license_setup
 
 ## Define where to get the config file (only used if running interactively)
-manual_config_file = "config/example_dev.yml"
+# manual_config_file = "config/config-base.yml"
+manual_config_file = Path(Path(__file__).parent, "..", "config", "config-base.yml").resolve()
 # ---- If not running interactively, the config file should be supplied as the command-line argument after the python script, e.g.: python metashape_workflow.py config.yml
 
 
@@ -28,7 +30,7 @@ def parse_args():
         + "All other arguments are optional overrides to the corresponding entry in that config"
     )
     parser.add_argument(
-        "config_file", default=manual_config_file, help="A path to a yaml config file."
+        "--config_file", default=manual_config_file, help="A path to a yaml config file."
     )
     parser.add_argument(
         "--photo-path",


### PR DESCRIPTION
- Workflow now selects our example config as a default (no need to pass in config file for default runs)
- Renamed config-example.yml to config-base.yml
- Removed filler file paths
- Made config-file a named argument
- Properly path for our config-base.yml