### PR TITLE
More consistent and more easily machine-readable output filenames

### DIFF
--- a/python/metashape_workflow.py
+++ b/python/metashape_workflow.py
@@ -1,10 +1,6 @@
 # -*- coding: utf-8 -*-
 # File for running a metashape workflow
 
-# Derek Young and Alex Mandel
-# University of California, Davis
-# 2021
-
 import argparse
 import sys
 from pathlib import Path

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -902,7 +902,7 @@ class MetashapeWorkflow:
             output_file = os.path.join(
                 self.cfg["output_path"],
                 self.run_id
-                + "_model_georeferenced."
+                + "_model-georeferenced."
                 + self.cfg["buildModel"]["export_extension"],
             )
             self.doc.chunk.exportModel(path=output_file)
@@ -920,7 +920,7 @@ class MetashapeWorkflow:
             if self.cfg["buildModel"]["export_transform"]:
                 output_file = os.path.join(
                     self.cfg["output_path"],
-                    self.run_id + "_local_model_transform.csv",
+                    self.run_id + "_local-model-transform.csv",
                 )
 
                 with open(output_file, "w") as fileh:
@@ -936,7 +936,7 @@ class MetashapeWorkflow:
             output_file = os.path.join(
                 self.cfg["output_path"],
                 self.run_id
-                + "_model_local."
+                + "_model-local."
                 + self.cfg["buildModel"]["export_extension"],
             )
             self.doc.chunk.exportModel(path=output_file)
@@ -1150,7 +1150,7 @@ class MetashapeWorkflow:
         ## Export orthomosaic
         if self.cfg["buildOrthomosaic"]["export"]:
             output_file = os.path.join(
-                self.cfg["output_path"], self.run_id + "_ortho_" + file_ending + ".tif"
+                self.cfg["output_path"], self.run_id + "_ortho-" + file_ending + ".tif"
             )
 
             compression = Metashape.ImageCompression()


### PR DESCRIPTION
There were some (arguable) inconsistencies in our output file naming convention. We generally have:
`{project_name}_{run_timestamp}_{product_type}.{extension}`

for example:
`000004_20240502T1919_dsm-mesh.tif`

But for orthomosaics and mesh, there is an additional underscore, e.g.:
`000004_20240502T1919_ortho_dsm-mesh.tif`

This makes machine-reading more difficult. So this PR makes it more consistent by turning the extra underscore to a hyphen, e.g.:
`000004_20240502T1919_ortho-dsm-mesh.tif`

This PR also removes the two named authors of the workflow script, now that it has many authors and code has shifted between files. Authors can be identified via the git history.