### PR TITLE
Update docker image to use latest Ubuntu (24.04) and Metashape (2.2.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install libraries/dependencies.
 # For GUI probably also need libglx-mesa0
 RUN apt-get update &&            \
-      apt-get install libgl1 libglu1-mesa -y \
+      apt-get install libglib2.0-dev libglib2.0-0 libgl1 libglu1-mesa -y \
       libcurl4 \
       wget && \
       rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update &&            \
 
 # Install the command line python module. Note that this does not install the GUI
 RUN apt-get update -y && apt-get install -y python3-pip
-RUN cd /opt && wget https://download.agisoft.com/Metashape-2.1.3-cp37.cp38.cp39.cp310.cp311-abi3-linux_x86_64.whl && \
-      pip3 install Metashape-2.1.3-cp37.cp38.cp39.cp310.cp311-abi3-linux_x86_64.whl && pip3 install PyYAML && \
+RUN cd /opt && wget https://download.agisoft.com/Metashape-2.2.0-cp37.cp38.cp39.cp310.cp311-abi3-linux_x86_64.whl && \
+      pip3 install Metashape-2.2.0-cp37.cp38.cp39.cp310.cp311-abi3-linux_x86_64.whl && pip3 install PyYAML && \
       rm -rf *.whl
 
 # Set the container workdir

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install libraries/dependencies
 RUN apt-get update &&            \
-      apt-get install libglib2.0-dev libglib2.0-0 glu -y \
+      apt-get install libglib2.0-dev libglib2.0-0 libgl1 -y \
       libcurl4 \
       wget && \
       rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a GPU-enabled base image
-FROM nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04
+FROM nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu22.04
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,10 @@ RUN echo "user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install libraries/dependencies
+# Install libraries/dependencies.
+# For GUI probably also need libglx-mesa0
 RUN apt-get update &&            \
-      apt-get install libglib2.0-dev libglib2.0-0 libgl1 -y \
+      apt-get install libglib2.0-dev libglib2.0-0 libgl1 libglu1-mesa -y \
       libcurl4 \
       wget && \
       rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 # Use a GPU-enabled base image
 FROM nvcr.io/nvidia/cudagl:11.4.1-runtime-ubuntu20.04
 
-# USER root
+USER root
 
 # Adapted from https://github.com/jeffgillan/agisoft_metashape/blob/main/Dockerfile
 LABEL authors="David Russell"
 LABEL maintainer="djrussell@ucdavis"
 
-# # Create user account with password-less sudo abilities
-# RUN useradd -s /bin/bash -g 100 -G sudo -m user
-# RUN /usr/bin/printf '%s\n%s\n' 'password' 'password'| passwd user
-# RUN echo "user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+# Create user account with password-less sudo abilities
+RUN useradd -s /bin/bash -g 100 -G sudo -m user
+RUN /usr/bin/printf '%s\n%s\n' 'password' 'password'| passwd user
+RUN echo "user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install libraries/dependencies
 RUN apt-get update &&            \
-      apt-get install libglib2.0-dev libglib2.0-0 -y \
+      apt-get install libglib2.0-dev libglib2.0-0 glu -y \
       libcurl4 \
       wget && \
       rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a GPU-enabled base image
-FROM nvcr.io/nvidia/cudagl:11.4.1-runtime-ubuntu20.04
+FROM nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install libraries/dependencies.
 # For GUI probably also need libglx-mesa0
 RUN apt-get update &&            \
-      apt-get install libglib2.0-dev libglib2.0-0 libgl1 libglu1-mesa -y \
+      apt-get install libgl1 libglu1-mesa -y \
       libcurl4 \
       wget && \
       rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install basic dependencies
 RUN apt-get update &&            \
-    apt-get install -y libglib2.0-dev libglib2.0-0 libgl1 libglu1-mesa libcurl4 wget python3-venv python3-full && \
+    apt-get install -y libglib2.0-dev libglib2.0-0 libgl1 libglu1-mesa libcurl4 wget python3-venv python3-full libgomp1 && \
     rm -rf /var/lib/apt/lists/*
 
 # Download the Metashape .whl file

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install libraries/dependencies
 RUN apt-get update &&            \
-      apt-get install -y libgl1-mesa-glx libglu1 \
+      apt-get install -y \
       libcurl4 \
       wget && \
       rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install libraries/dependencies
 RUN apt-get update &&            \
-      apt-get install -y \
+      apt-get install libglib2.0-dev libglib2.0-0 -y \
       libcurl4 \
       wget && \
       rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 # Use a GPU-enabled base image
 FROM nvcr.io/nvidia/cudagl:11.4.1-runtime-ubuntu20.04
 
-USER root
+# USER root
 
 # Adapted from https://github.com/jeffgillan/agisoft_metashape/blob/main/Dockerfile
 LABEL authors="David Russell"
 LABEL maintainer="djrussell@ucdavis"
 
-# Create user account with password-less sudo abilities
-RUN useradd -s /bin/bash -g 100 -G sudo -m user
-RUN /usr/bin/printf '%s\n%s\n' 'password' 'password'| passwd user
-RUN echo "user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+# # Create user account with password-less sudo abilities
+# RUN useradd -s /bin/bash -g 100 -G sudo -m user
+# RUN /usr/bin/printf '%s\n%s\n' 'password' 'password'| passwd user
+# RUN echo "user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
This requires also installing the metashape python module in a python venv, which is now enforced in U24.