### PR TITLE
Updates for metashape 2.2

### DIFF
--- a/config/config-base.yml
+++ b/config/config-base.yml
@@ -129,12 +129,12 @@ classifyGroundPoints: # (Metashape: classifyGroundPoints) # classify points, IF 
     max_distance: 1.0
     cell_size: 50.0
 
-buildModel:
+buildMesh:
     enabled: True
     face_count: "Metashape.MediumFaceCount" # How many faces to use, Metashape.LowFaceCount, MediumFaceCount, HighFaceCount, CustomFaceCount
     face_count_custom: 100000 # Only used if custom number of faces set (above).
-    export: True # Export the georeferenced model.
-    export_extension: "ply" # Can be any supported 3D model extension
+    export: True # Export the georeferenced mesh.
+    export_extension: "ply" # Can be any supported 3D mesh extension
 
 buildDem: # (Metashape: buildDem, (optionally) classifyGroundPoints, exportRaster)
     enabled: True

--- a/config/config-base.yml
+++ b/config/config-base.yml
@@ -133,9 +133,7 @@ buildModel:
     enabled: True
     face_count: "Metashape.MediumFaceCount" # How many faces to use, Metashape.LowFaceCount, MediumFaceCount, HighFaceCount, CustomFaceCount
     face_count_custom: 100000 # Only used if custom number of faces set (above).
-    export_local: True # Export the model in local coordinates
-    export_transform: False # Export the transform matrix for local model coords -> global coords
-    export_georeferenced: True # Export the georeferenced model. If there's no georeferencing it will be the same as local
+    export: True # Export the georeferenced model.
     export_extension: "ply" # Can be any supported 3D model extension
 
 buildDem: # (Metashape: buildDem, (optionally) classifyGroundPoints, exportRaster)

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -206,8 +206,8 @@ class MetashapeWorkflow:
         if self.cfg["buildPointCloud"]["enabled"]:
             self.build_point_cloud()
 
-        if self.cfg["buildModel"]["enabled"]:
-            self.build_model()
+        if self.cfg["buildMesh"]["enabled"]:
+            self.build_mesh()
 
         # For this step, the check for whether it is enabled in the config happens inside the function, because there are two steps (DEM and ortho), each of which can be enabled independently
         self.build_dem_orthomosaic()
@@ -922,9 +922,9 @@ class MetashapeWorkflow:
 
         return True
 
-    def build_model(self):
+    def build_mesh(self):
         """
-        Build and export the model
+        Build and export the mesh
         """
 
         start_time = time.time()
@@ -932,8 +932,8 @@ class MetashapeWorkflow:
         self.doc.chunk.buildModel(
             surface_type=Metashape.Arbitrary,
             interpolation=Metashape.EnabledInterpolation,
-            face_count=self.cfg["buildModel"]["face_count"],
-            face_count_custom=self.cfg["buildModel"][
+            face_count=self.cfg["buildMesh"]["face_count"],
+            face_count_custom=self.cfg["buildMesh"][
                 "face_count_custom"
             ],  # Only used if face_count is custom
             source_data=Metashape.DepthMapsData,
@@ -943,17 +943,15 @@ class MetashapeWorkflow:
 
         # record results to file
         with open(self.log_file, "a") as file:
-            file.write(MetashapeWorkflow.sep.join(["Build Model", time_taken]) + "\n")
+            file.write(MetashapeWorkflow.sep.join(["Build Mesh", time_taken]) + "\n")
 
-        # Save the model
+        # Save the mesh
         self.doc.save()
 
-        if self.cfg["buildModel"]["export"]:
+        if self.cfg["buildMesh"]["export"]:
             output_file = os.path.join(
                 self.cfg["output_path"],
-                self.run_id
-                + "_model."
-                + self.cfg["buildModel"]["export_extension"],
+                self.run_id + "_mesh." + self.cfg["buildMesh"]["export_extension"],
             )
             # Export the georeferenced mesh in the project CRS. The metadata file is the only thing
             # that encodes the CRS.
@@ -961,7 +959,7 @@ class MetashapeWorkflow:
             self.doc.chunk.exportModel(
                 path=output_file,
                 crs=Metashape.CoordinateSystem(self.cfg["project_crs"]),
-                save_metadata_xml=True
+                save_metadata_xml=True,
             )
 
         return True
@@ -1229,7 +1227,6 @@ class MetashapeWorkflow:
             file.write(
                 MetashapeWorkflow.sep.join(["Add secondary photos", time2]) + "\n"
             )
-
 
         # Align the secondary photos (really, align all photos, but only the secondary photos will be
         # affected because Metashape only matches and aligns photos that were not already

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -955,7 +955,6 @@ class MetashapeWorkflow:
             )
             # Export the georeferenced mesh in the project CRS. The metadata file is the only thing
             # that encodes the CRS.
-            # TODO This will probably break if there's no georeferencing information in the project
             self.doc.chunk.exportModel(
                 path=output_file,
                 crs=Metashape.CoordinateSystem(self.cfg["project_crs"]),


### PR DESCRIPTION
This does three things
- Previously when secondary cameras were added the new `chunk` transform was overwritten with the old version. Now this produces incorrect locations for both `primary` and `secondary` cameras. However, the using the updated transform not only produces cameras that are in the correct locations, but the initial locations of the `primary` cameras is preserved.
- Don't export local mesh. This seemed to be an arbitrary coordinate system, even when comparing to the primary cameras. This should be checked though.
- Explicitly request a CRS for the mesh output. 