### PR TITLE
Add spherical camera option and shift centering to avoid quantization

### DIFF
--- a/config/config-base.yml
+++ b/config/config-base.yml
@@ -34,12 +34,6 @@ run_name: ""
 # CRS EPSG code that project outputs should be in (projection should be in meter units and intended for the project area)
 project_crs: "EPSG::26910" # 26910 is UTM 10N
 
-# If True, add in a shift to the CRS so the mesh origin is at the camera EXIF average location and points are reported in a local frame - shifted from the normal CRS origin.
-# This is necessary when fine mesh detail is needed, since the natural export format of Metashape is float32 for meshes. In most CRS, that results in point quantization in the 5cm-20cm range
-# In order to save finer detail, set shift_crs_to_cameras to True, and then apply the inverse shift to the mesh model to recreate the true CRS values
-# The shift used is reported using the save_metadata_xml mechanism of exportModel
-shift_crs_to_cameras: False
-
 # Enable metashape "fine-level task subdivision" which reduces memory use by breaking processing into independent chunks that are run in series.
 # Assuming there's enough memory, it seems to run 10-20% faster by disabling subdividing. But large projects can run out memory and fail if subdivide is not enabled.
 subdivide_task: True
@@ -145,6 +139,11 @@ buildMesh:
     face_count_custom: 100000 # Only used if custom number of faces set (above).
     export: True # Export the georeferenced mesh.
     export_extension: "ply" # Can be any supported 3D mesh extension
+    # If True, add in a shift to the CRS so the mesh origin is at the camera EXIF average location and points are reported in a local frame - shifted from the normal CRS origin.
+    # This is necessary when fine mesh detail is needed, since the natural export format of Metashape is float32 for meshes. In most CRS, that results in point quantization in the 5cm-20cm range
+    # In order to save finer detail, set shift_crs_to_cameras to True, and then apply the inverse shift to the mesh model to recreate the true CRS values
+    # The shift used is reported using the save_metadata_xml mechanism of exportModel
+    shift_crs_to_cameras: False
 
 buildDem: # (Metashape: buildDem, (optionally) classifyGroundPoints, exportRaster)
     enabled: True

--- a/config/config-base.yml
+++ b/config/config-base.yml
@@ -65,13 +65,10 @@ addPhotos: # (Metashape: addPhotos)
   use_rtk: False # Whether to use image EXIF RTK flags to make image geospatial accuracy more precise. If enabled but photos don't have RTK data, will treat them as regular photos and use the nofix accuracy.
   fix_accuracy: 3 # Accuracy to set for photos that have a RTK fix, in units of the CRS
   nofix_accuracy: 25 # Accuracy to set for photos that have no fix, in units of the CRS
-
-# Choose what type of camera you are using:
-#   Frame: default, uses radial distortion to handle lens distortion
-#   Spherical: expects image data to come in in the equirectangular format
-setSensorType:
-  enabled: True
-  type: Metashape.Sensor.Type.Frame # Sets the camera type. Tested choices: Metashape.Sensor.Type.Frame, Metashape.Sensor.Type.Spherical
+  # Choose what type of camera you are using:
+  #   Frame: default, uses radial distortion to handle lens distortion
+  #   Spherical: expects image data to come in in the equirectangular format
+  sensor_type: Metashape.Sensor.Type.Frame # Sets the camera type. Tested choices: Metashape.Sensor.Type.Frame, Metashape.Sensor.Type.Spherical
 
 calibrateReflectance: # (Metahsape: calibrateReflectance)
     enabled: False

--- a/config/config-base.yml
+++ b/config/config-base.yml
@@ -34,6 +34,12 @@ run_name: ""
 # CRS EPSG code that project outputs should be in (projection should be in meter units and intended for the project area)
 project_crs: "EPSG::26910" # 26910 is UTM 10N
 
+# If True, add in a shift to the CRS so the origin is at the camera EXIF average location and points are reported in a local frame - shifted from the normal CRS origin.
+# This is necessary when fine detail is needed, since the natural export format of Metashape is float32 for point clouds and meshes. In most CRS, that results in point quantization in the 5cm-20cm range
+# In order to save finer detail, set shift_crs_to_cameras to True, and then apply the inverse shift to the model to recreate the true CRS values
+# The shift used is reported using the save_metadata_xml mechanism of exportModel
+shift_crs_to_cameras: False
+
 # Enable metashape "fine-level task subdivision" which reduces memory use by breaking processing into independent chunks that are run in series.
 # Assuming there's enough memory, it seems to run 10-20% faster by disabling subdividing. But large projects can run out memory and fail if subdivide is not enabled.
 subdivide_task: True
@@ -59,6 +65,13 @@ addPhotos: # (Metashape: addPhotos)
   use_rtk: False # Whether to use image EXIF RTK flags to make image geospatial accuracy more precise. If enabled but photos don't have RTK data, will treat them as regular photos and use the nofix accuracy.
   fix_accuracy: 3 # Accuracy to set for photos that have a RTK fix, in units of the CRS
   nofix_accuracy: 25 # Accuracy to set for photos that have no fix, in units of the CRS
+
+# Choose what type of camera you are using:
+#   Frame: default, uses radial distortion to handle lens distortion
+#   Spherical: expects image data to come in in the equirectangular format
+setSensorType:
+  enabled: True
+  type: Metashape.Sensor.Type.Frame # Sets the camera type. Tested choices: Metashape.Sensor.Type.Frame, Metashape.Sensor.Type.Spherical
 
 calibrateReflectance: # (Metahsape: calibrateReflectance)
     enabled: False

--- a/config/config-base.yml
+++ b/config/config-base.yml
@@ -34,9 +34,9 @@ run_name: ""
 # CRS EPSG code that project outputs should be in (projection should be in meter units and intended for the project area)
 project_crs: "EPSG::26910" # 26910 is UTM 10N
 
-# If True, add in a shift to the CRS so the origin is at the camera EXIF average location and points are reported in a local frame - shifted from the normal CRS origin.
-# This is necessary when fine detail is needed, since the natural export format of Metashape is float32 for point clouds and meshes. In most CRS, that results in point quantization in the 5cm-20cm range
-# In order to save finer detail, set shift_crs_to_cameras to True, and then apply the inverse shift to the model to recreate the true CRS values
+# If True, add in a shift to the CRS so the mesh origin is at the camera EXIF average location and points are reported in a local frame - shifted from the normal CRS origin.
+# This is necessary when fine mesh detail is needed, since the natural export format of Metashape is float32 for meshes. In most CRS, that results in point quantization in the 5cm-20cm range
+# In order to save finer detail, set shift_crs_to_cameras to True, and then apply the inverse shift to the mesh model to recreate the true CRS values
 # The shift used is reported using the save_metadata_xml mechanism of exportModel
 shift_crs_to_cameras: False
 

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -962,7 +962,7 @@ class MetashapeWorkflow:
         if self.cfg["buildMesh"]["export"]:
 
             # Check for whether shifting the coordinate frame is desired
-            if self.cfg["shift_crs_to_cameras"] is True:
+            if self.cfg["buildMesh"]["shift_crs_to_cameras"] is True:
                 shift = self.get_cameraset_origin()
             else:
                 shift = Metashape.Vector([0, 0, 0])
@@ -1324,12 +1324,11 @@ class MetashapeWorkflow:
         # Average the camera locations without using libraries like numpy
         x = 0.0
         y = 0.0
-        invalid = 0
+        n_valid = 0
         for camera in self.doc.chunk.cameras:
 
             # Check for missing GPS EXIF data
             if camera.reference.location is None:
-                invalid += 1
                 continue
 
             # Get the camera location in the project CRS
@@ -1340,9 +1339,9 @@ class MetashapeWorkflow:
             )
             x += location[0]
             y += location[1]
+            n_valid += 1
 
         # Average over the number of valid images
-        n_valid = len(self.doc.chunk.cameras) - invalid
         if n_valid > 0:
             x /= n_valid
             y /= n_valid

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -174,9 +174,6 @@ class MetashapeWorkflow:
         ):  # only add photos if there is a photo directory listed
             self.add_photos()
 
-        if self.cfg["setSensorType"]["enabled"]:
-            self.set_sensor_type()
-
         if self.cfg["calibrateReflectance"]["enabled"]:
             self.calibrate_reflectance()
 
@@ -466,18 +463,20 @@ class MetashapeWorkflow:
                         ]
                     )
 
+        # Set the sensor type (e.g. Frame camera, Spherical camera)
+        self.set_sensor_type(self.cfg["addPhotos"]["sensor_type"])
+
         self.doc.save()
 
         return True
 
-    def set_sensor_type(self):
+    def set_sensor_type(self, sensor_type):
         """
         Sets the type of sensor used for data collection. Tested choices so far:
-        Metashape.Sensor.Type.Frame, Metashape.Sensor.Type.Spherical. Default is Frame
-        if no sensor type is set.
+        Metashape.Sensor.Type.Frame, Metashape.Sensor.Type.Spherical.
         """
         for sensor in self.doc.chunk.sensors:
-            sensor.type = self.cfg["setSensorType"]["type"]
+            sensor.type = sensor_type
         self.doc.save()
         return True
 
@@ -910,7 +909,7 @@ class MetashapeWorkflow:
             if self.cfg["shift_crs_to_cameras"] is True:
                 shift = self.get_cameraset_origin()
             else:
-                shift = None
+                shift = Metashape.Vector([0, 0, 0])
 
             # Export the point cloud
             output_file = os.path.join(
@@ -993,7 +992,7 @@ class MetashapeWorkflow:
 
     def build_dem_orthomosaic(self):
         """
-        Build end export DEM
+        Build and export DEM
         """
 
         # classify ground points if specified
@@ -1336,7 +1335,7 @@ class MetashapeWorkflow:
         for camera in self.doc.chunk.cameras:
             # Get the camera location in the project CRS
             location = Metashape.CoordinateSystem.transform(
-                cam.reference.location,
+                camera.reference.location,
                 source=camera_crs,
                 target=Metashape.CoordinateSystem(self.cfg["project_crs"]),
             )

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -1332,7 +1332,14 @@ class MetashapeWorkflow:
         # Average the camera locations without using libraries like numpy
         x = 0.0
         y = 0.0
+        invalid = 0
         for camera in self.doc.chunk.cameras:
+
+            # Check for missing GPS EXIF data
+            if camera.reference.location is None:
+                invalid += 1
+                continue
+
             # Get the camera location in the project CRS
             location = Metashape.CoordinateSystem.transform(
                 camera.reference.location,
@@ -1341,9 +1348,12 @@ class MetashapeWorkflow:
             )
             x += location[0]
             y += location[1]
-        # Average over the number of cameras
-        x /= len(self.doc.chunk.cameras)
-        y /= len(self.doc.chunk.cameras)
+
+        # Average over the number of valid images
+        n_valid = len(self.doc.chunk.cameras) - invalid
+        if n_valid > 0:
+            x /= n_valid
+            y /= n_valid
 
         # Round the values for easier readability
         x = int(x / round) * round

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -905,12 +905,6 @@ class MetashapeWorkflow:
             else:
                 export_file_ending = "_points.laz"
 
-            # Check for whether shifting the coordinate frame is desired
-            if self.cfg["shift_crs_to_cameras"] is True:
-                shift = self.get_cameraset_origin()
-            else:
-                shift = Metashape.Vector([0, 0, 0])
-
             # Export the point cloud
             output_file = os.path.join(
                 self.cfg["output_path"], self.run_id + export_file_ending
@@ -923,7 +917,6 @@ class MetashapeWorkflow:
                     format=self.cfg["buildPointCloud"]["export_format"],
                     crs=Metashape.CoordinateSystem(self.cfg["project_crs"]),
                     subdivide_task=self.cfg["subdivide_task"],
-                    shift=shift,
                 )
                 self.written_paths["point_cloud_all_classes"] = output_file  # export
             else:
@@ -935,7 +928,6 @@ class MetashapeWorkflow:
                     crs=Metashape.CoordinateSystem(self.cfg["project_crs"]),
                     classes=self.cfg["buildPointCloud"]["classes"],
                     subdivide_task=self.cfg["subdivide_task"],
-                    shift=shift,
                 )
                 self.written_paths["point_cloud_subset_classes"] = output_file  # export
 

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -973,7 +973,7 @@ class MetashapeWorkflow:
             if self.cfg["shift_crs_to_cameras"] is True:
                 shift = self.get_cameraset_origin()
             else:
-                shift = None
+                shift = Metashape.Vector([0, 0, 0])
 
             output_file = os.path.join(
                 self.cfg["output_path"],


### PR DESCRIPTION
Adds the spherical camera option to automate-metashape and also adds the camera-shift capability (necessary for high-res georeferenced meshes and point clouds)

I did four test meshes ([see more details here](https://docs.google.com/presentation/d/1Jfl_z5veNrkcEeKV5yTtbLyJc3LssTDWNipmOJ4nOjc/edit?slide=id.g383e52e5795_0_16#slide=id.g383e52e5795_0_16)):
1. Spherical run (ST0077), with shift_crs_to_cameras = False **[Looks bad and quantized]**
<img width="1401" height="794" alt="Screenshot from 2025-09-29 11-17-12" src="https://github.com/user-attachments/assets/674b9422-4f4f-4daf-9374-4baacc9ec935" />

2. Spherical run (ST0077), with shift_crs_to_cameras = True **[Looks good and smooth]**
<img width="1401" height="794" alt="Screenshot from 2025-09-29 11-20-14" src="https://github.com/user-attachments/assets/cc1d318b-9523-445b-a16c-adabcf75ccb7" />

3. Drone run (dataset 0001), with sensor_type = Frame, with shift_crs_to_cameras = False **[Looks as before and quantized]**
<img width="1401" height="794" alt="Screenshot from 2025-09-29 11-22-56" src="https://github.com/user-attachments/assets/18d6e7af-7ade-41ad-a54f-43151f49f847" />

4. Drone run (dataset 0001), with sensor_type = Frame, with shift_crs_to_cameras = True **[Looks as before and smooth]**
<img width="1401" height="794" alt="Screenshot from 2025-09-29 13-00-35" src="https://github.com/user-attachments/assets/ccf9a6e0-7c2f-4267-90d6-caeb1c4c7dcf" />

Drone run settings:
```
photo_path: "/ofo-share/species-prediction-project/intermediate/raw_image_sets/0001_001435_001436/nadir"
output_path: "/ofo-share/scratch-eric/tmp/automate-test-drone-0001/"
project_path: "/ofo-share/scratch-eric/tmp/automate-test-drone-0001/metashape.psx"
run_name: "automate-test-drone-0001"
```