### PR TITLE
Streamline logging code and improve logging consistency; add CPU and GPU utilization metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN python3 -m venv /opt/venv_metashape
 # Activate the virtual environment and install Metashape and PyYAML
 RUN /opt/venv_metashape/bin/pip install --upgrade pip
 RUN /opt/venv_metashape/bin/pip install /opt/Metashape-2.2.0-cp37.cp38.cp39.cp310.cp311-abi3-linux_x86_64.whl
-RUN /opt/venv_metashape/bin/pip install PyYAML
+RUN /opt/venv_metashape/bin/pip install PyYAML psutil pynvml
 
 # Remove the downloaded wheel file
 RUN rm /opt/*.whl

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN python3 -m venv /opt/venv_metashape
 # Activate the virtual environment and install Metashape and PyYAML
 RUN /opt/venv_metashape/bin/pip install --upgrade pip
 RUN /opt/venv_metashape/bin/pip install /opt/Metashape-2.2.0-cp37.cp38.cp39.cp310.cp311-abi3-linux_x86_64.whl
-RUN /opt/venv_metashape/bin/pip install PyYAML psutil pynvml
+RUN /opt/venv_metashape/bin/pip install PyYAML psutil nvidia-ml-py
 
 # Remove the downloaded wheel file
 RUN rm /opt/*.whl

--- a/docs/step-workflow-implementation-plan.md
+++ b/docs/step-workflow-implementation-plan.md
@@ -1,0 +1,416 @@
+# Step-Based Workflow Refactoring for Argo Integration
+
+## Executive Summary
+
+Refactor automate-metashape to support running individual processing steps as separate container invocations, enabling integration with Argo Workflows for orchestrated, resource-efficient batch processing of multiple missions.
+
+---
+
+## Background & Motivation
+
+**Current State:** automate-metashape runs as a monolithic workflow—all processing steps execute sequentially in a single container/process. Steps are enabled/disabled via YAML config flags.
+
+**Target Use Case:** Integration into a larger Argo Workflows pipeline that:
+- Reads a list of drone missions to process
+- Runs pre-processing steps
+- Processes multiple missions **in parallel**, each with its own Metashape project
+- Runs post-processing steps
+- Assigns **CPU or GPU nodes** to steps based on computational requirements
+
+**Key Benefit:** GPU-intensive steps (depth maps, point cloud, mesh generation) can run on expensive GPU nodes while CPU-only steps (setup, export, GCP addition) run on cheaper CPU nodes, optimizing resource costs across parallel mission processing.
+
+---
+
+## Chosen Approach: Option C - WorkflowTemplate with Conditional Steps
+
+**Architecture:**
+- Define a fixed Argo WorkflowTemplate containing all possible Metashape processing steps
+- Each step has a `when` condition based on parameters (e.g., `when: "{{inputs.parameters.align-enabled}} == 'true'"`)
+- Steps with false conditions are **skipped without pod creation**—no resources allocated
+- Outer workflow fans out over missions, calling the template with mission-specific enabled flags
+
+**Why This Approach:**
+- **Resource efficient**: Disabled GPU steps don't allocate GPU nodes (Argo evaluates conditions before scheduling)
+- **Unified UI**: Single workflow view in Argo UI shows all missions and their step status
+- **Simple integration**: Uses native Argo features, no custom workflow generation logic
+- **Backward compatible**: Preserves ability to run full workflow in single command for local/manual use
+
+---
+
+## Phase 1: Enhanced Logging for Benchmarking
+
+### Objective
+
+Implement detailed per-API-call logging to benchmark processing times and resource utilization. This data will inform decisions about step granularity (which operations to lump together vs split).
+
+### Deliverables
+
+**Two log files per run:**
+
+1. **Human-readable log** (`{run_id}_log.txt`):
+   ```
+   Project Setup           | 00:00:03 | CPU: 12% | GPU: 0%
+   Add Photos              | 00:01:47 | CPU: 34% | GPU: 0%
+   Match Photos            | 01:23:45 | CPU: 42% | GPU: 91%
+   Align Cameras           | 00:08:12 | CPU: 38% | GPU: 85%
+   Build Depth Maps        | 02:15:33 | CPU: 45% | GPU: 88%
+   Build Point Cloud       | 00:45:22 | CPU: 51% | GPU: 76%
+   Build DEM (DSM-ptcloud) | 00:12:15 | CPU: 65% | GPU: 42%
+   Build Orthomosaic       | 00:18:33 | CPU: 58% | GPU: 38%
+   ```
+
+2. **Machine-readable log** (`{run_id}_metrics.yaml`):
+   ```yaml
+   - api_call: matchPhotos
+     duration_seconds: 5025.3
+     cpu_percent: 42.1
+     gpu_percent: 91.3
+
+   - api_call: alignCameras
+     duration_seconds: 492.7
+     cpu_percent: 38.4
+     gpu_percent: 85.2
+
+   - api_call: buildDepthMaps
+     duration_seconds: 8133.1
+     cpu_percent: 45.0
+     gpu_percent: 88.4
+   ```
+
+### Implementation
+
+1. **Monitoring infrastructure**
+   - Add `psutil` dependency for CPU monitoring
+   - Add `pynvml` dependency for GPU monitoring
+   - Create decorator/context manager to wrap Metashape API calls
+   - Background thread samples CPU/GPU utilization during call execution
+
+2. **Wrap all Metashape API calls**
+   - matchPhotos, alignCameras
+   - buildDepthMaps
+   - buildPointCloud, classifyGroundPoints
+   - buildModel
+   - buildDem (per DEM type)
+   - buildOrthomosaic (per surface)
+   - optimizeCameras
+   - Other API calls as needed
+
+3. **Output handling**
+   - Human log: append formatted line after each call
+   - YAML log: append structured entry after each call
+
+### Estimated Effort
+
+4-8 hours
+
+### Success Criteria
+
+- Every Metashape API call logs duration, CPU%, and GPU%
+- Both log formats generated correctly
+- Logs support append mode for multi-step workflow compatibility
+
+---
+
+## Phase 2: Step-Based Workflow Refactoring
+
+### Step Definitions
+
+Based on benchmarking data from Phase 1, the final step granularity may be adjusted. Initial step list:
+
+| Step | Operations | GPU Required |
+|------|------------|--------------|
+| `setup` | project_setup, add_photos, calibrate_reflectance | No |
+| `match-photos` | matchPhotos | **Yes** |
+| `align-cameras` | alignCameras | **Yes** |
+| `refine` | filter_points_part1, add_gcps, optimize_cameras, filter_points_part2, export_cameras | No |
+| `depth-maps` | buildDepthMaps | **Yes** |
+| `point-cloud` | buildPointCloud, classifyGroundPoints (optional) | **Yes** |
+| `mesh` | buildModel | **Yes** |
+| `dem` | buildDem (all configured types: DSM-ptcloud, DTM-ptcloud, DSM-mesh) | **Yes** |
+| `ortho` | buildOrthomosaic (all configured surfaces) | **Yes** |
+| `cleanup` | remove point cloud (if configured) | No |
+| `export` | export_report, finish_run | No |
+
+**Note:** After Phase 1 benchmarking, some steps may be combined if they're all CPU-bound and fast (e.g., dem + ortho + cleanup + export could become a single `products` step).
+
+### CLI Interface
+
+```bash
+# Current behavior preserved (runs all enabled steps)
+python metashape_workflow.py config.yml
+
+# New: run single step, load project from previous step
+python metashape_workflow.py config.yml --step match-photos
+python metashape_workflow.py config.yml --step depth-maps
+```
+
+### Implementation Details
+
+#### 1. Refactor for Step Execution
+
+- Add `--step` CLI argument to `metashape_workflow.py`
+- Create step dispatcher in `MetashapeWorkflow` class
+- Each step: loads project → executes operations → saves project
+
+```python
+def run_step(self, step_name):
+    """Run a single step, loading project from previous step."""
+    self.load_project()
+    self.validate_prerequisites(step_name)
+
+    step_methods = {
+        'setup': self.run_setup,
+        'match-photos': self.run_match_photos,
+        'align-cameras': self.run_align_cameras,
+        # ...
+    }
+
+    step_methods[step_name]()
+    self.doc.save()
+```
+
+#### 2. Break Apart Tightly Coupled Methods
+
+**`align_photos()`** → split into:
+- `run_match_photos()`: calls matchPhotos, saves
+- `run_align_cameras()`: calls alignCameras, saves
+
+**`build_dem_orthomosaic()`** → split into:
+- `run_dem()`: builds all configured DEMs (DSM-ptcloud, DTM-ptcloud, DSM-mesh)
+- `run_ortho()`: builds all configured orthomosaics
+- `run_cleanup()`: removes point cloud if configured
+
+#### 3. Unified Logging Across Steps
+
+- All steps append to the same log files in the output directory
+- Files opened in append mode
+- Sequential execution ensures no conflicts
+
+```python
+# Each step appends to unified logs
+with open(self.log_file, "a") as f:
+    f.write(f"{operation_name} | {duration} | CPU: {cpu}% | GPU: {gpu}%\n")
+```
+
+#### 4. Prerequisite Validation
+
+Each step validates required prior state:
+
+```python
+def validate_prerequisites(self, step_name):
+    prereqs = {
+        'align-cameras': lambda: self.doc.chunk.point_cloud is not None,  # needs match results
+        'depth-maps': lambda: len([c for c in self.doc.chunk.cameras if c.transform]) > 0,  # needs alignment
+        'dem': lambda: self.doc.chunk.point_cloud is not None or self.doc.chunk.model is not None,
+        'ortho': lambda: len(self.doc.chunk.elevations) > 0 or self.doc.chunk.model is not None,
+        # ...
+    }
+    if step_name in prereqs and not prereqs[step_name]():
+        raise ValueError(f"Prerequisites not met for step '{step_name}'")
+```
+
+### Estimated Effort
+
+- Refactor workflow into step dispatcher: 4-6 hours
+- Break apart coupled methods: 2-3 hours
+- Add prerequisite validation: 2-3 hours
+- Testing and documentation: 4-6 hours
+
+**Total: 12-18 hours**
+
+---
+
+## Phase 3: Argo Workflow Integration
+
+### WorkflowTemplate Structure
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: metashape-processing
+spec:
+  arguments:
+    parameters:
+      - name: project-path
+      - name: config-path
+      - name: match-photos-enabled
+      - name: align-cameras-enabled
+      - name: depth-maps-enabled
+      # ... other enabled flags
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: setup
+            template: cpu-step
+            arguments:
+              parameters:
+                - name: step
+                  value: "setup"
+
+          - name: match-photos
+            depends: "setup"
+            when: "{{workflow.parameters.match-photos-enabled}} == 'true'"
+            template: gpu-step
+            arguments:
+              parameters:
+                - name: step
+                  value: "match-photos"
+
+          - name: align-cameras
+            depends: "match-photos"
+            when: "{{workflow.parameters.align-cameras-enabled}} == 'true'"
+            template: gpu-step
+            arguments:
+              parameters:
+                - name: step
+                  value: "align-cameras"
+
+          - name: dem
+            depends: "point-cloud.Succeeded || mesh.Succeeded"
+            when: "{{workflow.parameters.dem-enabled}} == 'true'"
+            template: gpu-step
+            arguments:
+              parameters:
+                - name: step
+                  value: "dem"
+
+          - name: ortho
+            depends: "dem.Succeeded || dem.Skipped"
+            when: "{{workflow.parameters.ortho-enabled}} == 'true'"
+            template: gpu-step
+            arguments:
+              parameters:
+                - name: step
+                  value: "ortho"
+
+          - name: cleanup
+            depends: "ortho.Succeeded || ortho.Skipped"
+            when: "{{workflow.parameters.cleanup-enabled}} == 'true'"
+            template: cpu-step
+            arguments:
+              parameters:
+                - name: step
+                  value: "cleanup"
+
+          # ... additional steps
+
+    - name: cpu-step
+      inputs:
+        parameters:
+          - name: step
+      nodeSelector:
+        node-type: cpu
+      container:
+        image: metashape:latest
+        command: ["python", "metashape_workflow.py"]
+        args: ["{{workflow.parameters.config-path}}", "--step", "{{inputs.parameters.step}}"]
+        volumeMounts:
+          - name: shared-storage
+            mountPath: /data
+
+    - name: gpu-step
+      inputs:
+        parameters:
+          - name: step
+      nodeSelector:
+        nvidia.com/gpu: "true"
+      container:
+        image: metashape:latest
+        resources:
+          limits:
+            nvidia.com/gpu: 1
+        command: ["python", "metashape_workflow.py"]
+        args: ["{{workflow.parameters.config-path}}", "--step", "{{inputs.parameters.step}}"]
+        volumeMounts:
+          - name: shared-storage
+            mountPath: /data
+```
+
+### Outer Workflow Integration
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+spec:
+  templates:
+    - name: main
+      steps:
+        - - name: preprocess
+            template: preprocess-step
+
+        - - name: process-missions
+            template: metashape-processing
+            arguments:
+              parameters:
+                - name: config-path
+                  value: "{{item.config}}"
+                - name: match-photos-enabled
+                  value: "{{item.match_photos_enabled}}"
+                - name: dem-enabled
+                  value: "{{item.dem_enabled}}"
+                # ... other params
+            withParam: "{{steps.preprocess.outputs.parameters.missions}}"
+
+        - - name: postprocess
+            template: postprocess-step
+```
+
+### Estimated Effort
+
+- Create WorkflowTemplate YAML: 4-6 hours
+- Integration testing: 4-6 hours
+- Documentation: 2-3 hours
+
+**Total: 10-15 hours**
+
+---
+
+## Key Technical Considerations
+
+### Large Project Files
+
+Metashape `.psx` projects can be tens of GB. Use shared persistent storage (NFS/PVC) mounted to all pods—not Argo artifacts.
+
+### Metashape Licensing
+
+Floating license server must be accessible from all pods. Ensure `AGISOFT_FLS` environment variable is configured in all step containers.
+
+### Dependencies
+
+Add to Docker image:
+- `psutil` (CPU monitoring)
+- `pynvml` (GPU monitoring)
+
+---
+
+## Success Criteria
+
+### Phase 1
+- Every Metashape API call logs duration, CPU%, and GPU%
+- Both human-readable and YAML log formats generated
+- Benchmarking data available for step granularity decisions
+
+### Phase 2
+- Individual steps can be invoked via CLI
+- Steps produce valid project files that can be resumed
+- Full-workflow mode continues to work for local/manual use
+- Unified logs maintained across multi-step runs
+
+### Phase 3
+- Argo workflow correctly skips disabled steps without resource allocation
+- GPU steps run on GPU nodes, CPU steps on CPU nodes
+- Multiple missions process in parallel successfully
+- Complete visibility in Argo UI
+
+---
+
+## Timeline Summary
+
+| Phase | Deliverable | Effort |
+|-------|-------------|--------|
+| Phase 1 | Enhanced logging for benchmarking | 4-8 hours |
+| Phase 2 | Step-based workflow refactoring | 12-18 hours |
+| Phase 3 | Argo workflow integration | 10-15 hours |
+| **Total** | | **26-41 hours** |

--- a/python/benchmark_monitor.py
+++ b/python/benchmark_monitor.py
@@ -1,0 +1,178 @@
+"""
+Benchmark monitoring for Metashape API calls.
+
+Provides a context manager that wraps API calls and logs:
+- Duration
+- Average CPU utilization
+- Average GPU utilization
+
+Integrates with the existing log file and adds a machine-readable YAML format.
+"""
+
+import threading
+import time
+from contextlib import contextmanager
+
+import psutil
+import yaml
+
+# Try to import pynvml for GPU monitoring
+try:
+    import pynvml
+
+    PYNVML_AVAILABLE = True
+except ImportError:
+    PYNVML_AVAILABLE = False
+
+
+class BenchmarkMonitor:
+    """Monitor and log performance metrics for Metashape API calls."""
+
+    def __init__(self, log_file: str, yaml_log_path: str):
+        """
+        Initialize the benchmark monitor.
+
+        Args:
+            log_file: Path to existing human-readable log file (appends to it)
+            yaml_log_path: Path for machine-readable YAML metrics file
+        """
+        self.log_file = log_file
+        self.yaml_log_path = yaml_log_path
+
+        # GPU initialization
+        self.gpu_available = False
+        self.gpu_count = 0
+        if PYNVML_AVAILABLE:
+            try:
+                pynvml.nvmlInit()
+                self.gpu_count = pynvml.nvmlDeviceGetCount()
+                self.gpu_available = self.gpu_count > 0
+            except pynvml.NVMLError:
+                pass
+
+    def _format_duration(self, seconds: float) -> str:
+        """Format duration as HH:MM:SS."""
+        hours = int(seconds // 3600)
+        minutes = int((seconds % 3600) // 60)
+        secs = int(seconds % 60)
+        return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+
+    def _get_gpu_utilization(self) -> float:
+        """Get average GPU utilization across all GPUs."""
+        if not self.gpu_available:
+            return None
+
+        try:
+            total_util = 0
+            for i in range(self.gpu_count):
+                handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+                util = pynvml.nvmlDeviceGetUtilizationRates(handle)
+                total_util += util.gpu
+            return total_util / self.gpu_count
+        except pynvml.NVMLError:
+            return None
+
+    def log_step_header(self, step_name: str):
+        """
+        Write a step header to the human-readable log.
+
+        Args:
+            step_name: Name of the automate-metashape workflow step
+        """
+        with open(self.log_file, "a") as f:
+            f.write(f"\n=== {step_name} ===\n")
+
+    @contextmanager
+    def monitor(self, api_call_name: str):
+        """
+        Context manager to monitor a Metashape API call.
+
+        Args:
+            api_call_name: Name of the Metashape API method (e.g., "matchPhotos")
+
+        Usage:
+            with monitor.monitor("matchPhotos"):
+                chunk.matchPhotos(...)
+        """
+        # Sampling state
+        cpu_samples = []
+        gpu_samples = []
+        stop_sampling = threading.Event()
+
+        def sample_utilization():
+            """Background thread to sample CPU/GPU utilization."""
+            while not stop_sampling.is_set():
+                # CPU utilization (system-wide)
+                cpu_percent = psutil.cpu_percent(interval=None)
+                cpu_samples.append(cpu_percent)
+
+                # GPU utilization
+                gpu_util = self._get_gpu_utilization()
+                if gpu_util is not None:
+                    gpu_samples.append(gpu_util)
+
+                # Wait for next sample (1 second interval)
+                stop_sampling.wait(timeout=1.0)
+
+        # Start sampling thread
+        sampler = threading.Thread(target=sample_utilization, daemon=True)
+        start_time = time.time()
+        sampler.start()
+
+        try:
+            yield
+        finally:
+            # Stop sampling and wait for thread
+            stop_sampling.set()
+            sampler.join(timeout=2.0)
+            end_time = time.time()
+
+            # Calculate metrics
+            duration = end_time - start_time
+            avg_cpu = sum(cpu_samples) / len(cpu_samples) if cpu_samples else 0
+            avg_gpu = sum(gpu_samples) / len(gpu_samples) if gpu_samples else None
+
+            # Write to logs
+            self._write_human_log(api_call_name, duration, avg_cpu, avg_gpu)
+            self._write_yaml_log(api_call_name, duration, avg_cpu, avg_gpu)
+
+    def _write_human_log(
+        self, api_call: str, duration: float, cpu: float, gpu: float | None
+    ):
+        """Append entry to human-readable log."""
+        duration_str = self._format_duration(duration)
+        cpu_str = f"{cpu:.0f}%"
+        gpu_str = f"{gpu:.0f}%" if gpu is not None else "N/A"
+
+        with open(self.log_file, "a") as f:
+            f.write(
+                f"{api_call:<25} | {duration_str:>12} | {cpu_str:>8} | {gpu_str:>8}\n"
+            )
+
+    def _write_yaml_log(
+        self, api_call: str, duration: float, cpu: float, gpu: float | None
+    ):
+        """Append entry to YAML log."""
+        entry = {
+            "api_call": api_call,
+            "duration_seconds": round(duration, 1),
+            "cpu_percent": round(cpu, 1),
+        }
+
+        if gpu is not None:
+            entry["gpu_percent"] = round(gpu, 1)
+        else:
+            entry["gpu_percent"] = "N/A"
+
+        # Append to YAML file
+        with open(self.yaml_log_path, "a") as f:
+            yaml.dump([entry], f, default_flow_style=False)
+            f.write("\n")
+
+    def close(self):
+        """Clean up resources."""
+        if self.gpu_available and PYNVML_AVAILABLE:
+            try:
+                pynvml.nvmlShutdown()
+            except pynvml.NVMLError:
+                pass

--- a/python/benchmark_monitor.py
+++ b/python/benchmark_monitor.py
@@ -153,7 +153,7 @@ class BenchmarkMonitor:
 
         with open(self.log_file, "a") as f:
             f.write(
-                f"{api_call:<25} | {duration_str:>12} | {cpu_str:>8} | {gpu_str:>8}\n"
+                f"{api_call:<35} | {duration_str:>12} | {cpu_str:>8} | {gpu_str:>8}\n"
             )
 
     def _write_yaml_log(

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -828,7 +828,7 @@ class MetashapeWorkflow:
         with self.benchmark.monitor("buildDepthMaps (build)"):
             self.doc.chunk.buildDepthMaps(
                 downscale=self.cfg["buildDepthMaps"]["downscale"],
-                filter_mode=Metashape.NoFiltering,
+                filter_mode=Metashape.FilterMode.NoFiltering,
                 reuse_depth=self.cfg["buildDepthMaps"]["reuse_depth"],
                 max_neighbors=self.cfg["buildDepthMaps"]["max_neighbors"],
                 subdivide_task=self.cfg["subdivide_task"],

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -15,6 +15,8 @@ from pathlib import Path
 import Metashape
 import yaml
 
+from benchmark_monitor import BenchmarkMonitor
+
 
 #### Helper functions
 def recursive_update(d, u):
@@ -136,10 +138,13 @@ class MetashapeWorkflow:
         self.config_file = config_file
         self.doc = None
         self.log_file = None
+        self.yaml_log_file = None
         self.run_id = None
         self.cfg = None
         # track the written paths
         self.written_paths = {}
+        # benchmark monitor for performance logging
+        self.benchmark = None
         # Parse the yaml confif
         self.read_yaml()
         # Apply any manual overrides
@@ -256,6 +261,12 @@ class MetashapeWorkflow:
         self.log_file = os.path.join(
             self.cfg["output_path"], ".".join([self.run_id + "_log", "txt"])
         )
+        self.yaml_log_file = os.path.join(
+            self.cfg["output_path"], f"{self.run_id}_metrics.yaml"
+        )
+
+        # Initialize benchmark monitor for performance logging
+        self.benchmark = BenchmarkMonitor(self.log_file, self.yaml_log_file)
 
         """
         Create a doc and a chunk
@@ -360,12 +371,15 @@ class MetashapeWorkflow:
 
         return True
 
-    def add_photos(self, secondary=False):
+    def add_photos(self, secondary=False, log_header=True):
         """
         Add photos to project and change their labels to include their containing folder. Secondary: if
         True, this is a secondary set of photos to be aligned only, after all photogrammetry products
         have been produced from the primary set of photos.
         """
+
+        if log_header:
+            self.benchmark.log_step_header("Add Photos")
 
         if secondary:
             photo_paths = self.cfg["photo_path_secondary"]
@@ -397,11 +411,13 @@ class MetashapeWorkflow:
 
             ## Add them
             if self.cfg["addPhotos"]["multispectral"]:
-                self.doc.chunk.addPhotos(
-                    photo_files, layout=Metashape.MultiplaneLayout, group=grp
-                )
+                with self.benchmark.monitor("addPhotos"):
+                    self.doc.chunk.addPhotos(
+                        photo_files, layout=Metashape.MultiplaneLayout, group=grp
+                    )
             else:
-                self.doc.chunk.addPhotos(photo_files, group=grp)
+                with self.benchmark.monitor("addPhotos"):
+                    self.doc.chunk.addPhotos(photo_files, group=grp)
 
         ## Need to change the label on each camera so that it includes the containing folder(s)
         for camera in self.doc.chunk.cameras:
@@ -482,21 +498,28 @@ class MetashapeWorkflow:
 
     def calibrate_reflectance(self):
         # TODO: Handle failure to find panels, or mulitple panel images by returning error to user.
-        self.doc.chunk.locateReflectancePanels()
-        self.doc.chunk.loadReflectancePanelCalibration(
-            os.path.join(
-                self.cfg["photo_path"],
-                "calibration",
-                self.cfg["calibrateReflectance"]["panel_filename"],
+        self.benchmark.log_step_header("Calibrate Reflectance")
+
+        with self.benchmark.monitor("locateReflectancePanels"):
+            self.doc.chunk.locateReflectancePanels()
+
+        with self.benchmark.monitor("loadReflectancePanelCalibration"):
+            self.doc.chunk.loadReflectancePanelCalibration(
+                os.path.join(
+                    self.cfg["photo_path"],
+                    "calibration",
+                    self.cfg["calibrateReflectance"]["panel_filename"],
+                )
             )
-        )
-        # self.doc.chunk.calibrateReflectance(use_reflectance_panels=True,use_sun_sensor=True)
-        self.doc.chunk.calibrateReflectance(
-            use_reflectance_panels=self.cfg["calibrateReflectance"][
-                "use_reflectance_panels"
-            ],
-            use_sun_sensor=self.cfg["calibrateReflectance"]["use_sun_sensor"],
-        )
+
+        with self.benchmark.monitor("calibrateReflectance"):
+            self.doc.chunk.calibrateReflectance(
+                use_reflectance_panels=self.cfg["calibrateReflectance"][
+                    "use_reflectance_panels"
+                ],
+                use_sun_sensor=self.cfg["calibrateReflectance"]["use_sun_sensor"],
+            )
+
         self.doc.save()
 
         return True
@@ -506,6 +529,8 @@ class MetashapeWorkflow:
         Add GCPs (GCP coordinates and the locations of GCPs in individual photos.
         See the helper script (and the comments therein) for details on how to prepare the data needed by this function: R/prep_gcps.R
         """
+
+        self.benchmark.log_step_header("Add GCPs")
 
         # Determine the location of the GCPs file, which is also the base path to prepend to the GCP
         # camera label (relative to what's specified in the GCPs file, which is a relative path), to
@@ -604,50 +629,44 @@ class MetashapeWorkflow:
         return True
 
     def export_cameras(self):
+        self.benchmark.log_step_header("Export Cameras")
+
         output_file = os.path.join(
             self.cfg["output_path"], self.run_id + "_cameras.xml"
         )
         # Defaults to xml format, which is the only one we've used so far
-        self.doc.chunk.exportCameras(path=output_file)
+        with self.benchmark.monitor("exportCameras"):
+            self.doc.chunk.exportCameras(path=output_file)
         self.written_paths["camera_export"] = output_file  # export
 
-    def align_photos(self):
+    def align_photos(self, log_header=True):
         """
         Match photos, align cameras, optimize cameras
         """
 
-        #### Align photos
+        if log_header:
+            self.benchmark.log_step_header("Align Photos")
 
-        # get a beginning time stamp
-        timer1a = time.time()
+        with self.benchmark.monitor("matchPhotos"):
+            self.doc.chunk.matchPhotos(
+                downscale=self.cfg["alignPhotos"]["downscale"],
+                subdivide_task=self.cfg["subdivide_task"],
+                keep_keypoints=self.cfg["alignPhotos"]["keep_keypoints"],
+                generic_preselection=self.cfg["alignPhotos"]["generic_preselection"],
+                reference_preselection=self.cfg["alignPhotos"]["reference_preselection"],
+                reference_preselection_mode=self.cfg["alignPhotos"][
+                    "reference_preselection_mode"
+                ],
+            )
 
-        # Align cameras
-        self.doc.chunk.matchPhotos(
-            downscale=self.cfg["alignPhotos"]["downscale"],
-            subdivide_task=self.cfg["subdivide_task"],
-            keep_keypoints=self.cfg["alignPhotos"]["keep_keypoints"],
-            generic_preselection=self.cfg["alignPhotos"]["generic_preselection"],
-            reference_preselection=self.cfg["alignPhotos"]["reference_preselection"],
-            reference_preselection_mode=self.cfg["alignPhotos"][
-                "reference_preselection_mode"
-            ],
-        )
-        self.doc.chunk.alignCameras(
-            adaptive_fitting=self.cfg["alignPhotos"]["adaptive_fitting"],
-            subdivide_task=self.cfg["subdivide_task"],
-            reset_alignment=self.cfg["alignPhotos"]["reset_alignment"],
-        )
+        with self.benchmark.monitor("alignCameras"):
+            self.doc.chunk.alignCameras(
+                adaptive_fitting=self.cfg["alignPhotos"]["adaptive_fitting"],
+                subdivide_task=self.cfg["subdivide_task"],
+                reset_alignment=self.cfg["alignPhotos"]["reset_alignment"],
+            )
+
         self.doc.save()
-
-        # get an ending time stamp
-        timer1b = time.time()
-
-        # calculate difference between end and start time to 1 decimal place
-        time1 = diff_time(timer1b, timer1a)
-
-        # record processing time to file
-        with open(self.log_file, "a") as file:
-            file.write(MetashapeWorkflow.sep.join(["Align Photos", time1]) + "\n")
 
         return True
 
@@ -668,8 +687,7 @@ class MetashapeWorkflow:
         Optimize cameras
         """
 
-        # get a beginning time stamp
-        timer1a = time.time()
+        self.benchmark.log_step_header("Optimize Cameras")
 
         # Disable camera locations as reference if specified in YML
         if (
@@ -680,20 +698,10 @@ class MetashapeWorkflow:
             for i in range(0, n_cameras):
                 self.doc.chunk.cameras[i].reference.enabled = False
 
-        # Currently only optimizes the default parameters, which is not all possible parameters
-        self.doc.chunk.optimizeCameras(
-            adaptive_fitting=self.cfg["optimizeCameras"]["adaptive_fitting"]
-        )
-
-        # get an ending time stamp
-        timer1b = time.time()
-
-        # calculate difference between end and start time to 1 decimal place
-        time1 = diff_time(timer1b, timer1a)
-
-        # record results to file
-        with open(self.log_file, "a") as file:
-            file.write(MetashapeWorkflow.sep.join(["Optimize cameras", time1]) + "\n")
+        with self.benchmark.monitor("optimizeCameras"):
+            self.doc.chunk.optimizeCameras(
+                adaptive_fitting=self.cfg["optimizeCameras"]["adaptive_fitting"]
+            )
 
         self.doc.save()
 
@@ -701,12 +709,12 @@ class MetashapeWorkflow:
 
     def filter_points_usgs_part1(self):
 
-        # get a beginning time stamp
-        timer1a = time.time()
+        self.benchmark.log_step_header("Filter Points USGS Part 1")
 
-        self.doc.chunk.optimizeCameras(
-            adaptive_fitting=self.cfg["optimizeCameras"]["adaptive_fitting"]
-        )
+        with self.benchmark.monitor("optimizeCameras"):
+            self.doc.chunk.optimizeCameras(
+                adaptive_fitting=self.cfg["optimizeCameras"]["adaptive_fitting"]
+            )
 
         rec_thresh_percent = self.cfg["filterPointsUSGS"]["rec_thresh_percent"]
         rec_thresh_absolute = self.cfg["filterPointsUSGS"]["rec_thresh_absolute"]
@@ -724,9 +732,10 @@ class MetashapeWorkflow:
             thresh = rec_thresh_absolute  # don't throw away too many points if they're all good
         fltr.removePoints(thresh)
 
-        self.doc.chunk.optimizeCameras(
-            adaptive_fitting=self.cfg["optimizeCameras"]["adaptive_fitting"]
-        )
+        with self.benchmark.monitor("optimizeCameras"):
+            self.doc.chunk.optimizeCameras(
+                adaptive_fitting=self.cfg["optimizeCameras"]["adaptive_fitting"]
+            )
 
         fltr = Metashape.TiePoints.Filter()
         fltr.init(self.doc.chunk, Metashape.TiePoints.Filter.ProjectionAccuracy)
@@ -737,9 +746,10 @@ class MetashapeWorkflow:
             thresh = proj_thresh_absolute  # don't throw away too many points if they're all good
         fltr.removePoints(thresh)
 
-        self.doc.chunk.optimizeCameras(
-            adaptive_fitting=self.cfg["optimizeCameras"]["adaptive_fitting"]
-        )
+        with self.benchmark.monitor("optimizeCameras"):
+            self.doc.chunk.optimizeCameras(
+                adaptive_fitting=self.cfg["optimizeCameras"]["adaptive_fitting"]
+            )
 
         fltr = Metashape.TiePoints.Filter()
         fltr.init(self.doc.chunk, Metashape.TiePoints.Filter.ReprojectionError)
@@ -750,32 +760,21 @@ class MetashapeWorkflow:
             thresh = reproj_thresh_absolute  # don't throw away too many points if they're all good
         fltr.removePoints(thresh)
 
-        self.doc.chunk.optimizeCameras(
-            adaptive_fitting=self.cfg["optimizeCameras"]["adaptive_fitting"]
-        )
-
-        # get an ending time stamp
-        timer1b = time.time()
-
-        # calculate difference between end and start time to 1 decimal place
-        time1 = diff_time(timer1b, timer1a)
-
-        # record results to file
-        with open(self.log_file, "a") as file:
-            file.write(
-                MetashapeWorkflow.sep.join(["USGS filter points part 1", time1]) + "\n"
+        with self.benchmark.monitor("optimizeCameras"):
+            self.doc.chunk.optimizeCameras(
+                adaptive_fitting=self.cfg["optimizeCameras"]["adaptive_fitting"]
             )
 
         self.doc.save()
 
     def filter_points_usgs_part2(self):
 
-        # get a beginning time stamp
-        timer1a = time.time()
+        self.benchmark.log_step_header("Filter Points USGS Part 2")
 
-        self.doc.chunk.optimizeCameras(
-            adaptive_fitting=self.cfg["optimizeCameras"]["adaptive_fitting"]
-        )
+        with self.benchmark.monitor("optimizeCameras"):
+            self.doc.chunk.optimizeCameras(
+                adaptive_fitting=self.cfg["optimizeCameras"]["adaptive_fitting"]
+            )
 
         reproj_thresh_percent = self.cfg["filterPointsUSGS"]["reproj_thresh_percent"]
         reproj_thresh_absolute = self.cfg["filterPointsUSGS"]["reproj_thresh_absolute"]
@@ -789,73 +788,37 @@ class MetashapeWorkflow:
             thresh = reproj_thresh_absolute  # don't throw away too many points if they're all good
         fltr.removePoints(thresh)
 
-        self.doc.chunk.optimizeCameras(
-            adaptive_fitting=self.cfg["optimizeCameras"]["adaptive_fitting"]
-        )
-
-        # get an ending time stamp
-        timer1b = time.time()
-
-        # calculate difference between end and start time to 1 decimal place
-        time1 = diff_time(timer1b, timer1a)
-
-        # record results to file
-        with open(self.log_file, "a") as file:
-            file.write(
-                MetashapeWorkflow.sep.join(["USGS filter points part 2", time1]) + "\n"
+        with self.benchmark.monitor("optimizeCameras"):
+            self.doc.chunk.optimizeCameras(
+                adaptive_fitting=self.cfg["optimizeCameras"]["adaptive_fitting"]
             )
 
         self.doc.save()
 
     def classify_ground_points(self):
 
-        # get a beginning time stamp for the next step
-        timer_a = time.time()
-
-        self.doc.chunk.point_cloud.classifyGroundPoints(
-            max_angle=self.cfg["classifyGroundPoints"]["max_angle"],
-            max_distance=self.cfg["classifyGroundPoints"]["max_distance"],
-            cell_size=self.cfg["classifyGroundPoints"]["cell_size"],
-        )
-
-        # get an ending time stamp for the previous step
-        timer_b = time.time()
-
-        # calculate difference between end and start time to 1 decimal place
-        time_tot = diff_time(timer_b, timer_a)
+        with self.benchmark.monitor("classifyGroundPoints"):
+            self.doc.chunk.point_cloud.classifyGroundPoints(
+                max_angle=self.cfg["classifyGroundPoints"]["max_angle"],
+                max_distance=self.cfg["classifyGroundPoints"]["max_distance"],
+                cell_size=self.cfg["classifyGroundPoints"]["cell_size"],
+            )
 
         self.doc.save()
-
-        # record results to file
-        with open(self.log_file, "a") as file:
-            file.write(
-                MetashapeWorkflow.sep.join(["Classify Ground Points", time_tot]) + "\n"
-            )
 
     def build_depth_maps(self):
         ### Build depth maps
 
-        # get a beginning time stamp for the next step
-        timer2a = time.time()
+        self.benchmark.log_step_header("Build Depth Maps")
 
-        # build depth maps only instead of also building the point cloud ##?? what does
-        self.doc.chunk.buildDepthMaps(
-            downscale=self.cfg["buildDepthMaps"]["downscale"],
-            filter_mode=self.cfg["buildDepthMaps"]["filter_mode"],
-            reuse_depth=self.cfg["buildDepthMaps"]["reuse_depth"],
-            max_neighbors=self.cfg["buildDepthMaps"]["max_neighbors"],
-            subdivide_task=self.cfg["subdivide_task"],
-        )
-
-        # get an ending time stamp for the previous step
-        timer2b = time.time()
-
-        # calculate difference between end and start time to 1 decimal place
-        time2 = diff_time(timer2b, timer2a)
-
-        # record results to file
-        with open(self.log_file, "a") as file:
-            file.write(MetashapeWorkflow.sep.join(["Build Depth Maps", time2]) + "\n")
+        with self.benchmark.monitor("buildDepthMaps"):
+            self.doc.chunk.buildDepthMaps(
+                downscale=self.cfg["buildDepthMaps"]["downscale"],
+                filter_mode=self.cfg["buildDepthMaps"]["filter_mode"],
+                reuse_depth=self.cfg["buildDepthMaps"]["reuse_depth"],
+                max_neighbors=self.cfg["buildDepthMaps"]["max_neighbors"],
+                subdivide_task=self.cfg["subdivide_task"],
+            )
 
         self.doc.save()
 
@@ -864,28 +827,15 @@ class MetashapeWorkflow:
         Build point cloud
         """
 
-        ### Build point cloud
+        self.benchmark.log_step_header("Build Point Cloud")
 
-        # get a beginning time stamp for the next step
-        timer3a = time.time()
-
-        # build point cloud
-        self.doc.chunk.buildPointCloud(
-            max_neighbors=self.cfg["buildPointCloud"]["max_neighbors"],
-            keep_depth=self.cfg["buildPointCloud"]["keep_depth"],
-            subdivide_task=self.cfg["subdivide_task"],
-            point_colors=True,
-        )
-
-        # get an ending time stamp for the previous step
-        timer3b = time.time()
-
-        # calculate difference between end and start time to 1 decimal place
-        time3 = diff_time(timer3b, timer3a)
-
-        # record results to file
-        with open(self.log_file, "a") as file:
-            file.write(MetashapeWorkflow.sep.join(["Build Point Cloud", time3]) + "\n")
+        with self.benchmark.monitor("buildPointCloud"):
+            self.doc.chunk.buildPointCloud(
+                max_neighbors=self.cfg["buildPointCloud"]["max_neighbors"],
+                keep_depth=self.cfg["buildPointCloud"]["keep_depth"],
+                subdivide_task=self.cfg["subdivide_task"],
+                point_colors=True,
+            )
 
         self.doc.save()
 
@@ -911,24 +861,26 @@ class MetashapeWorkflow:
             )
             if self.cfg["buildPointCloud"]["classes"] == "ALL":
                 # call without classes argument (Metashape then defaults to all classes)
-                self.doc.chunk.exportPointCloud(
-                    path=output_file,
-                    source_data=Metashape.PointCloudData,
-                    format=self.cfg["buildPointCloud"]["export_format"],
-                    crs=Metashape.CoordinateSystem(self.cfg["project_crs"]),
-                    subdivide_task=self.cfg["subdivide_task"],
-                )
+                with self.benchmark.monitor("exportPointCloud"):
+                    self.doc.chunk.exportPointCloud(
+                        path=output_file,
+                        source_data=Metashape.PointCloudData,
+                        format=self.cfg["buildPointCloud"]["export_format"],
+                        crs=Metashape.CoordinateSystem(self.cfg["project_crs"]),
+                        subdivide_task=self.cfg["subdivide_task"],
+                    )
                 self.written_paths["point_cloud_all_classes"] = output_file  # export
             else:
                 # call with classes argument
-                self.doc.chunk.exportPointCloud(
-                    path=output_file,
-                    source_data=Metashape.PointCloudData,
-                    format=Metashape.PointCloudFormatLAZ,
-                    crs=Metashape.CoordinateSystem(self.cfg["project_crs"]),
-                    classes=self.cfg["buildPointCloud"]["classes"],
-                    subdivide_task=self.cfg["subdivide_task"],
-                )
+                with self.benchmark.monitor("exportPointCloud"):
+                    self.doc.chunk.exportPointCloud(
+                        path=output_file,
+                        source_data=Metashape.PointCloudData,
+                        format=Metashape.PointCloudFormatLAZ,
+                        crs=Metashape.CoordinateSystem(self.cfg["project_crs"]),
+                        classes=self.cfg["buildPointCloud"]["classes"],
+                        subdivide_task=self.cfg["subdivide_task"],
+                    )
                 self.written_paths["point_cloud_subset_classes"] = output_file  # export
 
         return True
@@ -938,23 +890,18 @@ class MetashapeWorkflow:
         Build and export the mesh
         """
 
-        start_time = time.time()
-        # Build the mesh
-        self.doc.chunk.buildModel(
-            surface_type=Metashape.Arbitrary,
-            interpolation=Metashape.EnabledInterpolation,
-            face_count=self.cfg["buildMesh"]["face_count"],
-            face_count_custom=self.cfg["buildMesh"][
-                "face_count_custom"
-            ],  # Only used if face_count is custom
-            source_data=Metashape.DepthMapsData,
-        )
+        self.benchmark.log_step_header("Build Mesh")
 
-        time_taken = diff_time(time.time(), start_time)
-
-        # record results to file
-        with open(self.log_file, "a") as file:
-            file.write(MetashapeWorkflow.sep.join(["Build Mesh", time_taken]) + "\n")
+        with self.benchmark.monitor("buildModel"):
+            self.doc.chunk.buildModel(
+                surface_type=Metashape.Arbitrary,
+                interpolation=Metashape.EnabledInterpolation,
+                face_count=self.cfg["buildMesh"]["face_count"],
+                face_count_custom=self.cfg["buildMesh"][
+                    "face_count_custom"
+                ],  # Only used if face_count is custom
+                source_data=Metashape.DepthMapsData,
+            )
 
         # Save the mesh
         self.doc.save()
@@ -973,12 +920,13 @@ class MetashapeWorkflow:
             )
             # Export the georeferenced mesh in the project CRS. The metadata file is the only thing
             # that encodes the CRS.
-            self.doc.chunk.exportModel(
-                path=output_file,
-                crs=Metashape.CoordinateSystem(self.cfg["project_crs"]),
-                save_metadata_xml=True,
-                shift=shift,
-            )
+            with self.benchmark.monitor("exportModel"):
+                self.doc.chunk.exportModel(
+                    path=output_file,
+                    crs=Metashape.CoordinateSystem(self.cfg["project_crs"]),
+                    save_metadata_xml=True,
+                    shift=shift,
+                )
 
         return True
 
@@ -992,6 +940,8 @@ class MetashapeWorkflow:
             self.classify_ground_points()
 
         if self.cfg["buildDem"]["enabled"]:
+            self.benchmark.log_step_header("Build DEM")
+
             # prepping params for buildDem
             projection = Metashape.OrthoProjection()
             projection.crs = Metashape.CoordinateSystem(self.cfg["project_crs"])
@@ -1003,114 +953,85 @@ class MetashapeWorkflow:
             compression.tiff_overviews = self.cfg["buildDem"]["tiff_overviews"]
 
             if "DSM-ptcloud" in self.cfg["buildDem"]["surface"]:
-                start_time = time.time()
-
-                # call without point classes argument (Metashape then defaults to all classes)
-                self.doc.chunk.buildDem(
-                    source_data=Metashape.PointCloudData,
-                    subdivide_task=self.cfg["subdivide_task"],
-                    projection=projection,
-                    resolution=self.cfg["buildDem"]["resolution"],
-                )
-
-                time_taken = diff_time(time.time(), start_time)
+                with self.benchmark.monitor("buildDem (DSM-ptcloud)"):
+                    self.doc.chunk.buildDem(
+                        source_data=Metashape.PointCloudData,
+                        subdivide_task=self.cfg["subdivide_task"],
+                        projection=projection,
+                        resolution=self.cfg["buildDem"]["resolution"],
+                    )
 
                 self.doc.chunk.elevation.label = "DSM-ptcloud"
-
-                # record results to file
-                with open(self.log_file, "a") as file:
-                    file.write(
-                        MetashapeWorkflow.sep.join(["Build DSM-ptcloud", time_taken])
-                        + "\n"
-                    )
 
                 output_file = os.path.join(
                     self.cfg["output_path"], self.run_id + "_dsm-ptcloud.tif"
                 )
                 if self.cfg["buildDem"]["export"]:
-                    self.doc.chunk.exportRaster(
-                        path=output_file,
-                        projection=projection,
-                        nodata_value=self.cfg["buildDem"]["nodata"],
-                        source_data=Metashape.ElevationData,
-                        image_compression=compression,
-                    )
+                    with self.benchmark.monitor("exportRaster (DSM-ptcloud)"):
+                        self.doc.chunk.exportRaster(
+                            path=output_file,
+                            projection=projection,
+                            nodata_value=self.cfg["buildDem"]["nodata"],
+                            source_data=Metashape.ElevationData,
+                            image_compression=compression,
+                        )
                     self.written_paths[f"DEM_{self.cfg['buildDem']['surface'][0]}"] = (
                         output_file  # export
                     )
-                # log to output file to variable
+
             if "DTM-ptcloud" in self.cfg["buildDem"]["surface"]:
-
-                start_time = time.time()
-
-                # call with point classes argument to specify ground points only
-                self.doc.chunk.buildDem(
-                    source_data=Metashape.PointCloudData,
-                    classes=Metashape.PointClass.Ground,
-                    subdivide_task=self.cfg["subdivide_task"],
-                    projection=projection,
-                    resolution=self.cfg["buildDem"]["resolution"],
-                )
-
-                time_taken = diff_time(time.time(), start_time)
+                with self.benchmark.monitor("buildDem (DTM-ptcloud)"):
+                    self.doc.chunk.buildDem(
+                        source_data=Metashape.PointCloudData,
+                        classes=Metashape.PointClass.Ground,
+                        subdivide_task=self.cfg["subdivide_task"],
+                        projection=projection,
+                        resolution=self.cfg["buildDem"]["resolution"],
+                    )
 
                 self.doc.chunk.elevation.label = "DTM-ptcloud"
-
-                # record results to file
-                with open(self.log_file, "a") as file:
-                    file.write(
-                        MetashapeWorkflow.sep.join(["Build DTM-ptcloud", time_taken])
-                        + "\n"
-                    )
 
                 output_file = os.path.join(
                     self.cfg["output_path"], self.run_id + "_dtm-ptcloud.tif"
                 )
                 if self.cfg["buildDem"]["export"]:
-                    self.doc.chunk.exportRaster(
-                        path=output_file,
-                        projection=projection,
-                        nodata_value=self.cfg["buildDem"]["nodata"],
-                        source_data=Metashape.ElevationData,
-                        image_compression=compression,
-                    )
+                    with self.benchmark.monitor("exportRaster (DTM-ptcloud)"):
+                        self.doc.chunk.exportRaster(
+                            path=output_file,
+                            projection=projection,
+                            nodata_value=self.cfg["buildDem"]["nodata"],
+                            source_data=Metashape.ElevationData,
+                            image_compression=compression,
+                        )
 
             if "DSM-mesh" in self.cfg["buildDem"]["surface"]:
-
-                start_time = time.time()
-
-                self.doc.chunk.buildDem(
-                    source_data=Metashape.ModelData,
-                    subdivide_task=self.cfg["subdivide_task"],
-                    projection=projection,
-                    resolution=self.cfg["buildDem"]["resolution"],
-                )
-
-                time_taken = diff_time(time.time(), start_time)
+                with self.benchmark.monitor("buildDem (DSM-mesh)"):
+                    self.doc.chunk.buildDem(
+                        source_data=Metashape.ModelData,
+                        subdivide_task=self.cfg["subdivide_task"],
+                        projection=projection,
+                        resolution=self.cfg["buildDem"]["resolution"],
+                    )
 
                 self.doc.chunk.elevation.label = "DSM-mesh"
-
-                # record results to file
-                with open(self.log_file, "a") as file:
-                    file.write(
-                        MetashapeWorkflow.sep.join(["Build DSM-mesh", time_taken])
-                        + "\n"
-                    )
 
                 output_file = os.path.join(
                     self.cfg["output_path"], self.run_id + "_dsm-mesh.tif"
                 )
                 if self.cfg["buildDem"]["export"]:
-                    self.doc.chunk.exportRaster(
-                        path=output_file,
-                        projection=projection,
-                        nodata_value=self.cfg["buildDem"]["nodata"],
-                        source_data=Metashape.ElevationData,
-                        image_compression=compression,
-                    )
+                    with self.benchmark.monitor("exportRaster (DSM-mesh)"):
+                        self.doc.chunk.exportRaster(
+                            path=output_file,
+                            projection=projection,
+                            nodata_value=self.cfg["buildDem"]["nodata"],
+                            source_data=Metashape.ElevationData,
+                            image_compression=compression,
+                        )
 
         # Each DEM has a label associated with it which is used to identify and activate the correct DEM for orthomosaic generation
         if self.cfg["buildOrthomosaic"]["enabled"]:
+            self.benchmark.log_step_header("Build Orthomosaic")
+
             # Iterate through each specified surface in the configuration
             for surface in self.cfg["buildOrthomosaic"]["surface"]:
                 if surface == "Mesh":
@@ -1150,9 +1071,6 @@ class MetashapeWorkflow:
         Note that we have tried using the 'resolution' parameter of buildOrthomosaic, but it does not have any effect. An orthomosaic built onto a DSM always has a reslution of 1/4 the DSM, and one built onto the mesh has a resolution of ~the GSD.
         """
 
-        # get a beginning time stamp for the next step
-        timer6a = time.time()
-
         # prepping params for buildDem
         projection = Metashape.OrthoProjection()
         projection.crs = Metashape.CoordinateSystem(self.cfg["project_crs"])
@@ -1162,24 +1080,15 @@ class MetashapeWorkflow:
         else:
             surface_data = Metashape.ElevationData
 
-        self.doc.chunk.buildOrthomosaic(
-            surface_data=surface_data,
-            blending_mode=self.cfg["buildOrthomosaic"]["blending"],
-            fill_holes=self.cfg["buildOrthomosaic"]["fill_holes"],
-            refine_seamlines=self.cfg["buildOrthomosaic"]["refine_seamlines"],
-            subdivide_task=self.cfg["subdivide_task"],
-            projection=projection,
-        )
-
-        # get an ending time stamp for the previous step
-        timer6b = time.time()
-
-        # calculate difference between end and start time to 1 decimal place
-        time6 = diff_time(timer6b, timer6a)
-
-        # record results to file
-        with open(self.log_file, "a") as file:
-            file.write(MetashapeWorkflow.sep.join(["Build Orthomosaic", time6]) + "\n")
+        with self.benchmark.monitor(f"buildOrthomosaic ({file_ending})"):
+            self.doc.chunk.buildOrthomosaic(
+                surface_data=surface_data,
+                blending_mode=self.cfg["buildOrthomosaic"]["blending"],
+                fill_holes=self.cfg["buildOrthomosaic"]["fill_holes"],
+                refine_seamlines=self.cfg["buildOrthomosaic"]["refine_seamlines"],
+                subdivide_task=self.cfg["subdivide_task"],
+                projection=projection,
+            )
 
         self.doc.save()
 
@@ -1197,13 +1106,14 @@ class MetashapeWorkflow:
             projection = Metashape.OrthoProjection()
             projection.crs = Metashape.CoordinateSystem(self.cfg["project_crs"])
 
-            self.doc.chunk.exportRaster(
-                path=output_file,
-                projection=projection,
-                nodata_value=self.cfg["buildOrthomosaic"]["nodata"],
-                source_data=Metashape.OrthomosaicData,
-                image_compression=compression,
-            )
+            with self.benchmark.monitor(f"exportRaster (ortho-{file_ending})"):
+                self.doc.chunk.exportRaster(
+                    path=output_file,
+                    projection=projection,
+                    nodata_value=self.cfg["buildOrthomosaic"]["nodata"],
+                    source_data=Metashape.OrthomosaicData,
+                    image_compression=compression,
+                )
             self.written_paths["ortho_" + file_ending] = output_file  # export
 
         if self.cfg["buildOrthomosaic"]["remove_after_export"]:
@@ -1228,28 +1138,15 @@ class MetashapeWorkflow:
                 "For aligning secondary photos, keep_keypoints must be True."
             )
 
-        # get a beginning time stamp for the next step
-        timer2a = time.time()
+        self.benchmark.log_step_header("Add/Align Secondary Photos")
 
         # Add the secondary photos
-        self.add_photos(secondary=True)
-
-        # get an ending time stamp for the previous step
-        timer2b = time.time()
-
-        # calculate difference between end and start time to 1 decimal place
-        time2 = diff_time(timer2b, timer2a)
-
-        # record results to file
-        with open(self.log_file, "a") as file:
-            file.write(
-                MetashapeWorkflow.sep.join(["Add secondary photos", time2]) + "\n"
-            )
+        self.add_photos(secondary=True, log_header=False)
 
         # Align the secondary photos (really, align all photos, but only the secondary photos will be
         # affected because Metashape only matches and aligns photos that were not already
         # matched/aligned, assuming keep_keypoints and reset_alignment were set as required).
-        self.align_photos()
+        self.align_photos(log_header=False)
 
         self.doc.save()
 
@@ -1258,9 +1155,12 @@ class MetashapeWorkflow:
         Export report
         """
 
+        self.benchmark.log_step_header("Export Report")
+
         output_file = os.path.join(self.cfg["output_path"], self.run_id + "_report.pdf")
 
-        self.doc.chunk.exportReport(path=output_file)
+        with self.benchmark.monitor("exportReport"):
+            self.doc.chunk.exportReport(path=output_file)
         self.written_paths["report"] = output_file  # export
 
         return True

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -828,24 +828,11 @@ class MetashapeWorkflow:
 
         self.benchmark.log_step_header("Build Depth Maps")
 
-        # First call: build depth maps without filtering
-        with self.benchmark.monitor("buildDepthMaps (build)"):
-            self.doc.chunk.buildDepthMaps(
-                downscale=self.cfg["buildDepthMaps"]["downscale"],
-                filter_mode=Metashape.FilterMode.NoFiltering,
-                reuse_depth=self.cfg["buildDepthMaps"]["reuse_depth"],
-                max_neighbors=self.cfg["buildDepthMaps"]["max_neighbors"],
-                subdivide_task=self.cfg["subdivide_task"],
-            )
-
-        self.doc.save()
-
-        # Second call: filter existing depth maps (reuse_depth forced to True)
-        with self.benchmark.monitor("buildDepthMaps (filter)"):
+        with self.benchmark.monitor("buildDepthMaps"):
             self.doc.chunk.buildDepthMaps(
                 downscale=self.cfg["buildDepthMaps"]["downscale"],
                 filter_mode=self.cfg["buildDepthMaps"]["filter_mode"],
-                reuse_depth=True,
+                reuse_depth=self.cfg["buildDepthMaps"]["reuse_depth"],
                 max_neighbors=self.cfg["buildDepthMaps"]["max_neighbors"],
                 subdivide_task=self.cfg["subdivide_task"],
             )

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -382,6 +382,10 @@ class MetashapeWorkflow:
             "main/depth_max_gpu_multiplier", self.cfg["gpu_multiplier"]
         )
 
+        # Write header for benchmark log
+        with open(self.log_file, "a") as file:
+            file.write(f"\n{'API Call':<35} | {'Run Time':>12} | {'CPU Util':>8} | {'GPU Util':>8}\n")
+
         return True
 
     def add_photos(self, secondary=False, log_header=True):

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -316,6 +316,7 @@ class MetashapeWorkflow:
             # write a line with CPU info - if possible, improve the way the CPU info is found / recorded
             file.write(MetashapeWorkflow.sep.join(["Node", platform.node()]) + "\n")
             file.write(MetashapeWorkflow.sep.join(["CPU", platform.processor()]) + "\n")
+            file.write(MetashapeWorkflow.sep.join(["CPU Cores Available", str(os.cpu_count())]) + "\n")
             # write two lines with GPU info: count and model names - this takes multiple steps to make it look clean in the end
 
     def enable_and_log_gpu(self):

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -325,7 +325,7 @@ class MetashapeWorkflow:
         # open the results file
         # TODO: records the Slurm values for actual cpus and ram allocated
         # https://slurm.schedmd.com/sbatch.html#lbAI
-        with open(self.log_file, "a") as file:
+        with open(self.log_file, "w") as file:
 
             # write a line with the Metashape version
             file.write(MetashapeWorkflow.sep.join(["Project", self.run_id]) + "\n")

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -125,7 +125,7 @@ def get_camera(chunk, label):
 
 class MetashapeWorkflow:
 
-    sep = "; "
+    sep = ": "
 
     def __init__(
         self,

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -824,11 +824,24 @@ class MetashapeWorkflow:
 
         self.benchmark.log_step_header("Build Depth Maps")
 
-        with self.benchmark.monitor("buildDepthMaps"):
+        # First call: build depth maps without filtering
+        with self.benchmark.monitor("buildDepthMaps (build)"):
+            self.doc.chunk.buildDepthMaps(
+                downscale=self.cfg["buildDepthMaps"]["downscale"],
+                filter_mode=Metashape.NoFiltering,
+                reuse_depth=self.cfg["buildDepthMaps"]["reuse_depth"],
+                max_neighbors=self.cfg["buildDepthMaps"]["max_neighbors"],
+                subdivide_task=self.cfg["subdivide_task"],
+            )
+
+        self.doc.save()
+
+        # Second call: filter existing depth maps (reuse_depth forced to True)
+        with self.benchmark.monitor("buildDepthMaps (filter)"):
             self.doc.chunk.buildDepthMaps(
                 downscale=self.cfg["buildDepthMaps"]["downscale"],
                 filter_mode=self.cfg["buildDepthMaps"]["filter_mode"],
-                reuse_depth=self.cfg["buildDepthMaps"]["reuse_depth"],
+                reuse_depth=True,
                 max_neighbors=self.cfg["buildDepthMaps"]["max_neighbors"],
                 subdivide_task=self.cfg["subdivide_task"],
             )


### PR DESCRIPTION
To inform a forthcoming redesign that separates out CPU- and GPU-dependent steps, this PR improves logging of compute time and resource utilization. Logging is now performed via a context manager that wraps each metashape API call. Every Metashape API call is logged for compute time and CPU/GPU utilization. No automate-metashape logistics logic is logged, but its impact should be negligible. The level of logging detail, and format of log data, is improved in the existing human-readable log. The log has sub-headers that correspond to different automate-metashape tasks (which may contain one or more metashape python API calls with associated logging). This also adds a machine-readable (YAML-format) log to enable potential future automated comparison among different benchmarking runs.

**This enhancement involved no changes to the automate-metashape user interface.**

Partial example of new human-readable log:

```
Project: g3large_04
Agisoft Metashape Professional Version: 2.2.0
Processing started: 20251121T2330
Node: ad961362ffb6
CPU: x86_64
CPU Cores Available: 16
Number of GPUs Found: 1
GPU Model: GRID A100X-20C
GPU Mask: 4294967295

API Call                            |     Run Time | CPU Util | GPU Util

=== Add Photos ===
addPhotos                           |     00:00:00 |       0% |       0%

=== Align Photos ===
matchPhotos                         |     00:01:18 |      10% |       6%
alignCameras                        |     00:00:32 |      86% |       0%

=== Optimize Cameras ===
optimizeCameras                     |     00:00:02 |      66% |       0%

=== Export Cameras ===
exportCameras                       |     00:00:00 |      36% |       0%

=== Build Depth Maps ===
buildDepthMaps                      |     00:01:51 |      29% |      44%
```

Partial example of machine-readable log:
```
system:
  cpu: x86_64
  cpu_cores_available: 16
  gpu_count: 1
  gpu_mask: 4294967295
  gpu_model: GRID A100X-20C
  node: ad961362ffb6
api_calls:
  - api_call: addPhotos
    duration_seconds: 0.4
    cpu_percent: 0.0
    gpu_percent: 0.0
  - api_call: matchPhotos
    duration_seconds: 78.5
    cpu_percent: 10.3
    gpu_percent: 6.5
  - api_call: alignCameras
    duration_seconds: 32.2
    cpu_percent: 85.6
    gpu_percent: 0.0
  - api_call: optimizeCameras
    duration_seconds: 2.4
    cpu_percent: 65.5
    gpu_percent: 0.0
  - api_call: exportCameras
    duration_seconds: 0.2
    cpu_percent: 35.7
    gpu_percent: 0.0
  - api_call: buildDepthMaps
    duration_seconds: 111.2
    cpu_percent: 28.9
    gpu_percent: 44.2
```
FYI: @russelldj 