### PR TITLE
Log system specs per processing step

### DIFF
--- a/python/benchmark_monitor.py
+++ b/python/benchmark_monitor.py
@@ -43,6 +43,7 @@ class BenchmarkMonitor:
         self.log_file = log_file
         self.yaml_log_path = yaml_log_path
         self.get_system_info_fn = get_system_info_fn
+        self.current_step = ""  # Store current step name
 
         # GPU initialization for monitoring
         self.gpu_available = False
@@ -83,13 +84,12 @@ class BenchmarkMonitor:
 
     def log_step_header(self, step_name: str):
         """
-        Write a step header to the human-readable log.
+        Store the current step name for inclusion in log entries.
 
         Args:
             step_name: Name of the automate-metashape workflow step
         """
-        with open(self.log_file, "a") as f:
-            f.write(f"\n=== {step_name} ===\n")
+        self.current_step = step_name
 
     @contextmanager
     def monitor(self, api_call_name: str):
@@ -153,8 +153,8 @@ class BenchmarkMonitor:
     ):
         """Append entry to human-readable log."""
         duration_str = self._format_duration(duration)
-        cpu_str = f"CPU: {cpu_percent:>2.0f}%"
-        gpu_str = f"GPU: {gpu_percent:>2.0f}%" if gpu_percent is not None else "GPU: N/A"
+        cpu_str = f"{cpu_percent:>3.0f}"
+        gpu_str = f"{gpu_percent:>3.0f}" if gpu_percent is not None else "N/A"
 
         # Extract node info - use "N/A" for missing values in TXT log
         cpu_cores_available = system_info.get("cpu_cores_available", "N/A")
@@ -164,8 +164,8 @@ class BenchmarkMonitor:
 
         with open(self.log_file, "a") as f:
             f.write(
-                f"{api_call:<24} | {duration_str} | {cpu_str} | {gpu_str} | "
-                f"CPUs: {cpu_cores_available:>7} | GPU: {gpu_count} | {gpu_model:<15} | {node_name:<15}\n"
+                f"{self.current_step:<18} | {api_call:<24} | {duration_str} | {cpu_str:>5} | {gpu_str:>5} | "
+                f"{cpu_cores_available:>4} | {gpu_count:>4} | {gpu_model:<15} | {node_name:<15}\n"
             )
 
     def _write_yaml_log(

--- a/python/benchmark_monitor.py
+++ b/python/benchmark_monitor.py
@@ -9,6 +9,8 @@ Provides a context manager that wraps API calls and logs:
 Integrates with the existing log file and adds a machine-readable YAML format.
 """
 
+import os
+import platform
 import threading
 import time
 from contextlib import contextmanager
@@ -28,19 +30,21 @@ except ImportError:
 class BenchmarkMonitor:
     """Monitor and log performance metrics for Metashape API calls."""
 
-    def __init__(self, log_file: str, yaml_log_path: str, system_info: dict = None):
+    def __init__(self, log_file: str, yaml_log_path: str, get_system_info_fn=None):
         """
         Initialize the benchmark monitor.
 
         Args:
             log_file: Path to existing human-readable log file (appends to it)
             yaml_log_path: Path for machine-readable YAML metrics file
-            system_info: Dictionary with system information (node, cpu, cores, gpu_count, gpu_model)
+            get_system_info_fn: Callable that returns current system info dict.
+                                Called fresh for each API call to handle different nodes per step.
         """
         self.log_file = log_file
         self.yaml_log_path = yaml_log_path
+        self.get_system_info_fn = get_system_info_fn
 
-        # GPU initialization
+        # GPU initialization for monitoring
         self.gpu_available = False
         self.gpu_count = 0
         if PYNVML_AVAILABLE:
@@ -51,11 +55,9 @@ class BenchmarkMonitor:
             except pynvml.NVMLError:
                 pass
 
-        # Write YAML header with system info
-        if system_info:
-            with open(self.yaml_log_path, "w") as f:
-                yaml.dump({"system": system_info}, f, default_flow_style=False)
-                f.write("api_calls:\n")
+        # Write YAML header - system info will be per-call now
+        with open(self.yaml_log_path, "w") as f:
+            f.write("api_calls:\n")
 
     def _format_duration(self, seconds: float) -> str:
         """Format duration as HH:MM:SS."""
@@ -134,40 +136,65 @@ class BenchmarkMonitor:
             sampler.join(timeout=2.0)
             end_time = time.time()
 
-            # Calculate metrics
-            duration = end_time - start_time
-            avg_cpu = sum(cpu_samples) / len(cpu_samples) if cpu_samples else 0
-            avg_gpu = sum(gpu_samples) / len(gpu_samples) if gpu_samples else None
+            # Calculate and round metrics to 1 decimal place
+            duration = round(end_time - start_time, 1)
+            cpu_percent = round(sum(cpu_samples) / len(cpu_samples), 1) if cpu_samples else 0.0
+            gpu_percent = round(sum(gpu_samples) / len(gpu_samples), 1) if gpu_samples else None
+
+            # Get fresh system info for this API call (may be different node per step)
+            system_info = self.get_system_info_fn() if self.get_system_info_fn else {}
 
             # Write to logs
-            self._write_human_log(api_call_name, duration, avg_cpu, avg_gpu)
-            self._write_yaml_log(api_call_name, duration, avg_cpu, avg_gpu)
+            self._write_human_log(api_call_name, duration, cpu_percent, gpu_percent, system_info)
+            self._write_yaml_log(api_call_name, duration, cpu_percent, gpu_percent, system_info)
 
     def _write_human_log(
-        self, api_call: str, duration: float, cpu: float, gpu: float | None
+        self, api_call: str, duration: float, cpu_percent: float, gpu_percent: float | None, system_info: dict
     ):
         """Append entry to human-readable log."""
         duration_str = self._format_duration(duration)
-        cpu_str = f"{cpu:.0f}%"
-        gpu_str = f"{gpu:.0f}%" if gpu is not None else "N/A"
+        cpu_str = f"CPU: {cpu_percent:>2.0f}%"
+        gpu_str = f"GPU: {gpu_percent:>2.0f}%" if gpu_percent is not None else "GPU: N/A"
+
+        # Extract node info - use "N/A" for missing values in TXT log
+        cpu_cores_available = system_info.get("cpu_cores_available", "N/A")
+        gpu_count = system_info.get("gpu_count", "N/A")
+        gpu_model = system_info.get("gpu_model", "N/A")
+        node_name = system_info.get("node", "N/A")
 
         with open(self.log_file, "a") as f:
             f.write(
-                f"{api_call:<35} | {duration_str:>12} | {cpu_str:>8} | {gpu_str:>8}\n"
+                f"{api_call:<24} | {duration_str} | {cpu_str} | {gpu_str} | "
+                f"CPUs: {cpu_cores_available:>7} | GPU: {gpu_count} | {gpu_model:<15} | {node_name:<15}\n"
             )
 
     def _write_yaml_log(
-        self, api_call: str, duration: float, cpu: float, gpu: float | None
+        self, api_call: str, duration: float, cpu_percent: float, gpu_percent: float | None, system_info: dict
     ):
         """Append entry to YAML log."""
-        gpu_value = round(gpu, 1) if gpu is not None else "N/A"
+        # Extract node info and convert None to 'null' for proper YAML formatting
+        cpu_cores_available = system_info.get("cpu_cores_available")
+        gpu_count = system_info.get("gpu_count")
+        gpu_model = system_info.get("gpu_model")
+        node_name = system_info.get("node")
+
+        # Convert None to 'null' string for valid YAML
+        cpu_cores_available = cpu_cores_available if cpu_cores_available is not None else 'null'
+        gpu_count = gpu_count if gpu_count is not None else 'null'
+        gpu_model = gpu_model if gpu_model is not None else 'null'
+        node_name = node_name if node_name is not None else 'null'
+        gpu_percent = gpu_percent if gpu_percent is not None else 'null'
 
         # Write as indented list item under api_calls
         with open(self.yaml_log_path, "a") as f:
             f.write(f"  - api_call: {api_call}\n")
-            f.write(f"    duration_seconds: {round(duration, 1)}\n")
-            f.write(f"    cpu_percent: {round(cpu, 1)}\n")
-            f.write(f"    gpu_percent: {gpu_value}\n")
+            f.write(f"    duration_seconds: {duration}\n")
+            f.write(f"    cpu_percent: {cpu_percent}\n")
+            f.write(f"    gpu_percent: {gpu_percent}\n")
+            f.write(f"    cpu_cores_available: {cpu_cores_available}\n")
+            f.write(f"    gpu_count: {gpu_count}\n")
+            f.write(f"    gpu_model: {gpu_model}\n")
+            f.write(f"    node_name: {node_name}\n")
 
     def close(self):
         """Clean up resources."""

--- a/python/benchmark_monitor.py
+++ b/python/benchmark_monitor.py
@@ -159,7 +159,7 @@ class BenchmarkMonitor:
         # Extract node info - use "N/A" for missing values in TXT log
         cpu_cores_available = system_info.get("cpu_cores_available", "N/A")
         gpu_count = system_info.get("gpu_count", "N/A")
-        gpu_model = system_info.get("gpu_model", "N/A")
+        gpu_model = system_info.get("gpu_model") or "N/A"
         node_name = system_info.get("node", "N/A")
 
         with open(self.log_file, "a") as f:

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -287,12 +287,11 @@ class MetashapeWorkflow:
             self.cfg["output_path"], f"{self.run_id}_metrics.yaml"
         )
 
-        # Gather system info for logging
-        self.system_info = self._get_system_info()
-
         # Initialize benchmark monitor for performance logging
+        # Pass _get_system_info as a callable so it can be called fresh for each API call
+        # (since each step may run on a different node)
         self.benchmark = BenchmarkMonitor(
-            self.log_file, self.yaml_log_file, self.system_info
+            self.log_file, self.yaml_log_file, self._get_system_info
         )
 
         """
@@ -340,48 +339,22 @@ class MetashapeWorkflow:
             file.write(
                 MetashapeWorkflow.sep.join(["Processing started", stamp_time()]) + "\n"
             )
-            # write system info
-            file.write(
-                MetashapeWorkflow.sep.join(["Node", self.system_info["node"]]) + "\n"
-            )
-            file.write(
-                MetashapeWorkflow.sep.join(["CPU", self.system_info["cpu"]]) + "\n"
-            )
-            file.write(
-                MetashapeWorkflow.sep.join(
-                    [
-                        "CPU Cores Available",
-                        str(self.system_info["cpu_cores_available"]),
-                    ]
-                )
-                + "\n"
-            )
+            # Node and system specs are now logged per-step
 
     def enable_and_log_gpu(self):
         """
-        Enables GPU and logs GPU specs
+        Configure GPU settings for Metashape
         """
+        system_info = self._get_system_info()
+        gpucount = system_info["gpu_count"]
+        gpu_mask = system_info["gpu_mask"]
 
-        gpucount = self.system_info["gpu_count"]
-        gpustring = self.system_info["gpu_model"]
-        gpu_mask = self.system_info["gpu_mask"]
-
-        with open(self.log_file, "a") as file:
-            file.write(
-                MetashapeWorkflow.sep.join(["Number of GPUs Found", str(gpucount)])
-                + "\n"
-            )
-            file.write(MetashapeWorkflow.sep.join(["GPU Model", gpustring]) + "\n")
-            file.write(MetashapeWorkflow.sep.join(["GPU Mask", str(gpu_mask)]) + "\n")
-
-            # If a GPU exists but is not enabled, enable the 1st one
-            if (gpucount > 0) and (gpu_mask == 0):
-                Metashape.app.gpu_mask = 1
-                gpu_mask = Metashape.app.gpu_mask
-                file.write(
-                    MetashapeWorkflow.sep.join(["GPU Mask Enabled", str(gpu_mask)])
-                    + "\n"
-                )
+        # If GPUs exist but are not all enabled, enable all of them
+        if gpucount > 0:
+            # Create mask with all GPUs enabled (bitmask with gpucount bits set)
+            all_gpus_mask = (1 << gpucount) - 1
+            if gpu_mask != all_gpus_mask:
+                Metashape.app.gpu_mask = all_gpus_mask
 
         # set Metashape to *not* use the CPU during GPU steps (appears to be standard wisdom)
         Metashape.app.cpu_enable = False
@@ -398,7 +371,8 @@ class MetashapeWorkflow:
         # Write header for benchmark log
         with open(self.log_file, "a") as file:
             file.write(
-                f"\n{'API Call':<35} | {'Run Time':>12} | {'CPU Util':>8} | {'GPU Util':>8}\n"
+                f"\n{'API Call':<24} | {'Run Time':>8} | {'CPU %':>10} | {'GPU %':>10} | "
+                f"{'CPUs':>11} | {'GPU'} | {'GPU Model':<15} | {'Node':<15}\n"
             )
 
         return True

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -371,8 +371,8 @@ class MetashapeWorkflow:
         # Write header for benchmark log
         with open(self.log_file, "a") as file:
             file.write(
-                f"\n{'API Call':<24} | {'Run Time':>8} | {'CPU %':>10} | {'GPU %':>10} | "
-                f"{'CPUs':>11} | {'GPU'} | {'GPU Model':<15} | {'Node':<15}\n"
+                f"\n{'Step':<18} | {'API Call':<24} | {'Run Time':>8} | {'CPU %':>5} | {'GPU %':>5} | "
+                f"{'CPUs':>4} | {'GPUs':>4} | {'GPU Model':<15} | {'Node':<15}\n"
             )
 
         return True


### PR DESCRIPTION
This changes logging of system specs (#CPUs, #GPUS, GPU model, node name) so that it is done for each API call, as columns in the processing stats table (which as a row per API call). This is to support log interpretation in cases where a workflow was run on different nodes for different steps (a forthcoming feature).

 It also collapses the steps headers into a new column so that the headers don't interrupt the table. The new table looks like this:

```
Step               | API Call                 | Run Time | CPU % | GPU % | CPUs | GPUs | GPU Model       | Node           
Add Photos         | addPhotos                | 00:00:02 |    38 |     0 |   16 |    1 | GRID A100X-20C  | 67c4aab47b25   
Align Photos       | matchPhotos              | 00:11:33 |    14 |     6 |   16 |    1 | GRID A100X-20C  | 67c4aab47b25   
Align Photos       | alignCameras             | 00:25:59 |    78 |     0 |   16 |    1 | GRID A100X-20C  | 67c4aab47b25   
Optimize Cameras   | optimizeCameras          | 00:02:06 |    71 |     0 |   16 |    1 | GRID A100X-20C  | 67c4aab47b25   
Export Cameras     | exportCameras            | 00:00:00 |    10 |     0 |   16 |    1 | GRID A100X-20C  | 67c4aab47b25   
```

FYI @russelldj 