### PR TITLE
Add CPU P90 & max memory usage to resource monitoring/logging

### DIFF
--- a/python/benchmark_monitor.py
+++ b/python/benchmark_monitor.py
@@ -5,6 +5,7 @@ Provides a context manager that wraps API calls and logs:
 - Duration
 - Average CPU utilization
 - Average GPU utilization
+- Peak memory usage (process, container, and system level)
 
 Integrates with the existing log file and adds a machine-readable YAML format.
 """
@@ -14,6 +15,7 @@ import platform
 import threading
 import time
 from contextlib import contextmanager
+from pathlib import Path
 
 import psutil
 import yaml
@@ -25,6 +27,53 @@ try:
     PYNVML_AVAILABLE = True
 except ImportError:
     PYNVML_AVAILABLE = False
+
+
+# cgroups v2 paths for container memory limits
+CGROUP_V2_MEMORY_MAX = Path("/sys/fs/cgroup/memory.max")
+CGROUP_V2_MEMORY_CURRENT = Path("/sys/fs/cgroup/memory.current")
+
+
+def _is_in_cgroup_v2() -> bool:
+    """Check if running inside a cgroups v2 container with memory limits."""
+    return CGROUP_V2_MEMORY_MAX.exists() and CGROUP_V2_MEMORY_CURRENT.exists()
+
+
+def _read_cgroup_memory_limit() -> int | None:
+    """
+    Read container memory limit from cgroups v2.
+
+    Returns:
+        Memory limit in bytes, or None if unlimited/unavailable.
+    """
+    try:
+        content = CGROUP_V2_MEMORY_MAX.read_text().strip()
+        if content == "max":
+            # No limit set, return None to indicate unlimited
+            return None
+        return int(content)
+    except (OSError, ValueError):
+        return None
+
+
+def _read_cgroup_memory_current() -> int | None:
+    """
+    Read current container memory usage from cgroups v2.
+
+    Returns:
+        Current memory usage in bytes, or None if unavailable.
+    """
+    try:
+        return int(CGROUP_V2_MEMORY_CURRENT.read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _bytes_to_gb(bytes_val: int | None) -> float | None:
+    """Convert bytes to gigabytes, handling None."""
+    if bytes_val is None:
+        return None
+    return bytes_val / (1024 * 1024 * 1024)
 
 
 class BenchmarkMonitor:
@@ -97,6 +146,78 @@ class BenchmarkMonitor:
         except Exception:
             return 0.0
 
+    def _get_process_memory_bytes(self) -> int:
+        """
+        Get RSS memory usage in bytes for this process and all children.
+
+        Returns:
+            Total RSS memory in bytes across main process and all subprocesses.
+        """
+        try:
+            processes = [self.process] + self.process.children(recursive=True)
+            total_rss = 0
+            for proc in processes:
+                try:
+                    total_rss += proc.memory_info().rss
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    continue
+            return total_rss
+        except Exception:
+            return 0
+
+    def _get_memory_metrics(self) -> dict:
+        """
+        Get comprehensive memory metrics for process, container, and system.
+
+        Returns:
+            Dictionary with memory metrics in GB:
+            - proc_mem_gb: Process + children RSS
+            - container_limit_gb: Container memory limit (or system total if no container)
+            - container_used_gb: Container memory used (or system used if no container)
+            - container_avail_gb: Container memory available (limit - used)
+            - sys_total_gb: System total memory (node level)
+            - sys_used_gb: System used memory (node level)
+            - sys_avail_gb: System available memory (node level)
+        """
+        # Process memory (always from psutil)
+        proc_mem_bytes = self._get_process_memory_bytes()
+
+        # System memory (node level, always from psutil)
+        sys_mem = psutil.virtual_memory()
+        sys_total = sys_mem.total
+        sys_used = sys_mem.used
+        sys_avail = sys_mem.available
+
+        # Container memory (from cgroups v2 if available, else fall back to system)
+        if _is_in_cgroup_v2():
+            container_limit = _read_cgroup_memory_limit()
+            container_used = _read_cgroup_memory_current()
+
+            # If limit is None (unlimited), fall back to system total
+            if container_limit is None:
+                container_limit = sys_total
+
+            # If current read failed, fall back to system used
+            if container_used is None:
+                container_used = sys_used
+
+            container_avail = container_limit - container_used
+        else:
+            # Not in a container, use system values
+            container_limit = sys_total
+            container_used = sys_used
+            container_avail = sys_avail
+
+        return {
+            "proc_mem_gb": _bytes_to_gb(proc_mem_bytes),
+            "container_limit_gb": _bytes_to_gb(container_limit),
+            "container_used_gb": _bytes_to_gb(container_used),
+            "container_avail_gb": _bytes_to_gb(container_avail),
+            "sys_total_gb": _bytes_to_gb(sys_total),
+            "sys_used_gb": _bytes_to_gb(sys_used),
+            "sys_avail_gb": _bytes_to_gb(sys_avail),
+        }
+
     def _get_gpu_utilization(self) -> float:
         """Get average GPU utilization across all GPUs."""
         if not self.gpu_available:
@@ -140,10 +261,11 @@ class BenchmarkMonitor:
         cpu_samples = []
         gpu_samples = []
         process_cpu_samples = []
+        memory_samples = []  # List of memory metric dicts
         stop_sampling = threading.Event()
 
         def sample_utilization():
-            """Background thread to sample CPU/GPU utilization."""
+            """Background thread to sample CPU/GPU/memory utilization."""
             while not stop_sampling.is_set():
                 # CPU utilization (system-wide)
                 cpu_percent = psutil.cpu_percent(interval=None)
@@ -157,6 +279,10 @@ class BenchmarkMonitor:
                 # Process CPU usage (in cores)
                 process_cpu = self._get_process_cpu_cores()
                 process_cpu_samples.append(process_cpu)
+
+                # Memory metrics (for peak tracking)
+                mem_metrics = self._get_memory_metrics()
+                memory_samples.append(mem_metrics)
 
                 # Wait for next sample (1 second interval)
                 stop_sampling.wait(timeout=1.0)
@@ -188,6 +314,42 @@ class BenchmarkMonitor:
                 else 0.0
             )
 
+            # Calculate peak memory metrics
+            if memory_samples:
+                peak_memory = {
+                    "proc_mem_peak_gb": round(
+                        max(s["proc_mem_gb"] for s in memory_samples), 1
+                    ),
+                    "container_limit_gb": round(
+                        memory_samples[-1]["container_limit_gb"], 1
+                    ),
+                    "container_used_peak_gb": round(
+                        max(s["container_used_gb"] for s in memory_samples), 1
+                    ),
+                    "container_avail_min_gb": round(
+                        min(s["container_avail_gb"] for s in memory_samples), 1
+                    ),
+                    "sys_total_gb": round(memory_samples[-1]["sys_total_gb"], 1),
+                    "sys_used_peak_gb": round(
+                        max(s["sys_used_gb"] for s in memory_samples), 1
+                    ),
+                    "sys_avail_min_gb": round(
+                        min(s["sys_avail_gb"] for s in memory_samples), 1
+                    ),
+                }
+            else:
+                # No samples, get current snapshot
+                current_mem = self._get_memory_metrics()
+                peak_memory = {
+                    "proc_mem_peak_gb": round(current_mem["proc_mem_gb"], 1),
+                    "container_limit_gb": round(current_mem["container_limit_gb"], 1),
+                    "container_used_peak_gb": round(current_mem["container_used_gb"], 1),
+                    "container_avail_min_gb": round(current_mem["container_avail_gb"], 1),
+                    "sys_total_gb": round(current_mem["sys_total_gb"], 1),
+                    "sys_used_peak_gb": round(current_mem["sys_used_gb"], 1),
+                    "sys_avail_min_gb": round(current_mem["sys_avail_gb"], 1),
+                }
+
             # Get fresh system info for this API call (may be different node per step)
             system_info = self.get_system_info_fn() if self.get_system_info_fn else {}
 
@@ -198,6 +360,7 @@ class BenchmarkMonitor:
                 cpu_percent,
                 gpu_percent,
                 process_cpu_cores,
+                peak_memory,
                 system_info,
             )
             self._write_yaml_log(
@@ -206,6 +369,7 @@ class BenchmarkMonitor:
                 cpu_percent,
                 gpu_percent,
                 process_cpu_cores,
+                peak_memory,
                 system_info,
             )
 
@@ -216,6 +380,7 @@ class BenchmarkMonitor:
         cpu_percent: float,
         gpu_percent: float | None,
         process_cpu_cores: float,
+        peak_memory: dict,
         system_info: dict,
     ):
         """Append entry to human-readable log."""
@@ -230,10 +395,22 @@ class BenchmarkMonitor:
         gpu_model = system_info.get("gpu_model") or "N/A"
         node_name = system_info.get("node", "N/A")
 
+        # Format memory values (in GB, with 1 decimal place)
+        proc_mem = f"{peak_memory['proc_mem_peak_gb']:>6.1f}"
+        ctr_limit = f"{peak_memory['container_limit_gb']:>6.1f}"
+        ctr_used = f"{peak_memory['container_used_peak_gb']:>6.1f}"
+        ctr_avail = f"{peak_memory['container_avail_min_gb']:>6.1f}"
+        sys_total = f"{peak_memory['sys_total_gb']:>6.1f}"
+        sys_used = f"{peak_memory['sys_used_peak_gb']:>6.1f}"
+        sys_avail = f"{peak_memory['sys_avail_min_gb']:>6.1f}"
+
         with open(self.log_file, "a") as f:
             f.write(
-                f"{self.current_step:<23} | {api_call:<35} | {duration_str} | {cpu_str:>5} | {gpu_str:>5} | "
-                f"{process_cpu_str:>9} | {cpu_cores_available:>4} | {gpu_count:>4} | {gpu_model:<15} | {node_name:<15}\n"
+                f"{self.current_step:<23} | {api_call:<35} | {duration_str} | "
+                f"{cpu_str:>5} | {gpu_str:>5} | {process_cpu_str:>9} | "
+                f"{proc_mem} | {ctr_limit} | {ctr_used} | {ctr_avail} | "
+                f"{sys_total} | {sys_used} | {sys_avail} | "
+                f"{cpu_cores_available:>4} | {gpu_count:>4} | {gpu_model:<15} | {node_name:<15}\n"
             )
 
     def _write_yaml_log(
@@ -243,6 +420,7 @@ class BenchmarkMonitor:
         cpu_percent: float,
         gpu_percent: float | None,
         process_cpu_cores: float,
+        peak_memory: dict,
         system_info: dict,
     ):
         """Append entry to YAML log."""
@@ -269,6 +447,19 @@ class BenchmarkMonitor:
             f.write(f"    gpu_percent: {gpu_percent}\n")
             f.write(f"    cpu_cores_used: {process_cpu_cores}\n")
             f.write(f"    cpu_cores_available: {cpu_cores_available}\n")
+            # Memory metrics (all in GB)
+            f.write(f"    proc_mem_peak_gb: {peak_memory['proc_mem_peak_gb']}\n")
+            f.write(f"    container_limit_gb: {peak_memory['container_limit_gb']}\n")
+            f.write(
+                f"    container_used_peak_gb: {peak_memory['container_used_peak_gb']}\n"
+            )
+            f.write(
+                f"    container_avail_min_gb: {peak_memory['container_avail_min_gb']}\n"
+            )
+            f.write(f"    sys_total_gb: {peak_memory['sys_total_gb']}\n")
+            f.write(f"    sys_used_peak_gb: {peak_memory['sys_used_peak_gb']}\n")
+            f.write(f"    sys_avail_min_gb: {peak_memory['sys_avail_min_gb']}\n")
+            # GPU and node info
             f.write(f"    gpu_count: {gpu_count}\n")
             f.write(f"    gpu_model: {gpu_model}\n")
             f.write(f"    node_name: {node_name}\n")

--- a/python/benchmark_monitor.py
+++ b/python/benchmark_monitor.py
@@ -145,6 +145,18 @@ class BenchmarkMonitor:
         secs = int(seconds % 60)
         return f"{hours:02d}:{minutes:02d}:{secs:02d}"
 
+    def write_log_header(self):
+        """Write header row to human-readable log file. Memory columns are in GB."""
+        with open(self.log_file, "a") as f:
+            f.write(
+                f"\n{'Step':<23} | {'API Call':<35} | {'Run Time':>8} | "
+                f"{'CPU %':>5} | {'CPU%P90':>6} | {'GPU %':>5} | {'GPU%P90':>6} | "
+                f"{'CPU usage':>9} | {'CPUusgP90':>10} | "
+                f"{'PrcMem':>6} | {'CtrLim':>6} | {'CtrUsd':>6} | {'CtrAvl':>6} | "
+                f"{'SysTot':>6} | {'SysUsd':>6} | {'SysAvl':>6} | "
+                f"{'CPUs':>4} | {'GPUs':>4} | {'GPU Model':<15} | {'Node':<15}\n"
+            )
+
     def _get_process_cpu_cores(self) -> float:
         """
         Get CPU usage in cores for this process and all children.

--- a/python/benchmark_monitor.py
+++ b/python/benchmark_monitor.py
@@ -134,10 +134,6 @@ class BenchmarkMonitor:
         # Get current process for CPU monitoring (including all children)
         self.process = psutil.Process()
 
-        # Write YAML header - system info will be per-call now
-        with open(self.yaml_log_path, "w") as f:
-            f.write("api_calls:\n")
-
     def _format_duration(self, seconds: float) -> str:
         """Format duration as HH:MM:SS."""
         hours = int(seconds // 3600)
@@ -156,6 +152,11 @@ class BenchmarkMonitor:
                 f"{'SysTot':>6} | {'SysUsd':>6} | {'SysAvl':>6} | "
                 f"{'CPUs':>4} | {'GPUs':>4} | {'GPU Model':<15} | {'Node':<15}\n"
             )
+
+    def write_yaml_header(self):
+        """Initialize the YAML log file with header. Call once per run."""
+        with open(self.yaml_log_path, "w") as f:
+            f.write("api_calls:\n")
 
     def _get_process_cpu_cores(self) -> float:
         """

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -843,8 +843,9 @@ class MetashapeWorkflow:
         # set Metashape to *not* use the CPU during GPU steps (appears to be standard wisdom)
         Metashape.app.cpu_enable = False
 
-        # Write header for benchmark log
+        # Write headers for benchmark logs
         self.benchmark.write_log_header()
+        self.benchmark.write_yaml_header()
 
         return True
 

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -843,15 +843,8 @@ class MetashapeWorkflow:
         # set Metashape to *not* use the CPU during GPU steps (appears to be standard wisdom)
         Metashape.app.cpu_enable = False
 
-        # Write header for benchmark log (memory columns in GB)
-        with open(self.log_file, "a") as file:
-            file.write(
-                f"\n{'Step':<23} | {'API Call':<35} | {'Run Time':>8} | "
-                f"{'CPU %':>5} | {'GPU %':>5} | {'CPU usage':>9} | "
-                f"{'PrcMem':>6} | {'CtrLim':>6} | {'CtrUsd':>6} | {'CtrAvl':>6} | "
-                f"{'SysTot':>6} | {'SysUsd':>6} | {'SysAvl':>6} | "
-                f"{'CPUs':>4} | {'GPUs':>4} | {'GPU Model':<15} | {'Node':<15}\n"
-            )
+        # Write header for benchmark log
+        self.benchmark.write_log_header()
 
         return True
 

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -843,11 +843,14 @@ class MetashapeWorkflow:
         # set Metashape to *not* use the CPU during GPU steps (appears to be standard wisdom)
         Metashape.app.cpu_enable = False
 
-        # Write header for benchmark log
+        # Write header for benchmark log (memory columns in GB)
         with open(self.log_file, "a") as file:
             file.write(
-                f"\n{'Step':<23} | {'API Call':<35} | {'Run Time':>8} | {'CPU %':>5} | {'GPU %':>5} | "
-                f"{'CPU usage':>9} | {'CPUs':>4} | {'GPUs':>4} | {'GPU Model':<15} | {'Node':<15}\n"
+                f"\n{'Step':<23} | {'API Call':<35} | {'Run Time':>8} | "
+                f"{'CPU %':>5} | {'GPU %':>5} | {'CPU usage':>9} | "
+                f"{'PrcMem':>6} | {'CtrLim':>6} | {'CtrUsd':>6} | {'CtrAvl':>6} | "
+                f"{'SysTot':>6} | {'SysUsd':>6} | {'SysAvl':>6} | "
+                f"{'CPUs':>4} | {'GPUs':>4} | {'GPU Model':<15} | {'Node':<15}\n"
             )
 
         return True


### PR DESCRIPTION
The resource usage log files now include memory availability & usage (max during process execution) columns (for the process, container, and whole node). They also include 90th percentile CPU usage in addition to mean. The code for creating the log header is now also moved to the logging source file rather than the workflow file (more consistent).

```
Step                    | API Call                            | Run Time | CPU % | CPU%P90 | GPU % | GPU%P90 | CPU usage |  CPUusgP90 | PrcMem | CtrLim | CtrUsd | CtrAvl | SysTot | SysUsd | SysAvl | CPUs | GPUs | GPU Model       | Node           
setup                   | addPhotos                           | 00:00:20 |     3 |      3 |   N/A |    N/A |       0.2 |        0.2 |    0.3 |  122.8 |    9.6 |  113.2 |  122.8 |    2.3 |  120.5 |   32 |    0 | N/A             | automate-metashape-workflow-g95x4-metashape-cpu-step-1644225960
match_photos            | matchPhotos                         | 00:14:23 |    47 |     59 |   N/A |    N/A |      14.9 |       18.8 |    1.4 |  122.8 |   14.2 |  108.7 |  122.8 |    3.3 |  119.5 |   32 |    0 | N/A             | automate-metashape-workflow-g95x4-metashape-cpu-step-44022021
align_cameras           | alignCameras                        | 00:06:21 |    68 |     93 |   N/A |    N/A |      21.7 |       29.8 |    1.4 |  122.8 |    1.6 |  121.2 |  122.8 |    3.4 |  119.4 |   32 |    0 | N/A             | automate-metashape-workflow-g95x4-metashape-cpu-step-3097553909
align_cameras           | optimizeCameras                     | 00:00:34 |    58 |     89 |   N/A |    N/A |      18.5 |       28.5 |    1.3 |  122.8 |    1.8 |  121.1 |  122.8 |    3.2 |  119.6 |   32 |    0 | N/A             | automate-metashape-workflow-g95x4-metashape-cpu-step-3097553909
align_cameras           | exportCameras                       | 00:00:00 |     9 |      9 |   N/A |    N/A |       2.8 |        2.8 |    0.6 |  122.8 |    1.1 |  121.8 |  122.8 |    2.5 |  120.3 |   32 |    0 | N/A             | automate-metashape-workflow-g95x4-metashape-cpu-step-3097553909
build_depth_maps        | buildDepthMaps                      | 00:19:24 |    20 |     27 |    55 |     97 |       6.3 |        8.6 |    6.5 |  115.1 |   21.6 |   93.6 |  115.1 |    9.6 |  105.6 |   32 |    1 | NVIDIA A100-SXM4-40GB | automate-metashape-workflow-g95x4-metashape-gpu-step-3785861367
build_point_cloud       | buildPointCloud                     | 00:20:51 |    68 |     82 |   N/A |    N/A |      21.7 |       26.3 |   10.5 |  122.8 |   24.2 |   98.6 |  122.8 |   12.5 |  110.3 |   32 |    0 | N/A             | automate-metashape-workflow-g95x4-metashape-cpu-step-823056706

```