### PR TITLE
Add gpu_resource config option for MIG support on OFO cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,22 @@ python metashape_workflow.py --config-file config.yml --step finalize
 
 <br/>
 
+#### Argo workflow configuration (OFO Kubernetes cluster)
+
+When running via the [OFO Argo workflow orchestration system](https://github.com/open-forest-observatory/ofo-argo), additional configuration options control GPU resource allocation:
+
+- **`gpu_enabled`** (for `match_photos`, `build_mesh`): If `true`, the step runs on a GPU node; if `false`, it runs on a CPU node. Defaults to `true`. This has no effect on local execution where Metashape auto-detects available hardware.
+
+- **`gpu_resource`** (for `match_photos`, `build_depth_maps`, `build_mesh`): Specifies which GPU resource to request. Options:
+  - `"nvidia.com/gpu"` - Full GPU (default)
+  - `"nvidia.com/mig-1g.10gb"` - MIG partition: 1/7 compute, 10GB VRAM
+  - `"nvidia.com/mig-2g.10gb"` - MIG partition: 2/7 compute, 10GB VRAM
+  - `"nvidia.com/mig-3g.20gb"` - MIG partition: 3/7 compute, 20GB VRAM
+
+  MIG (Multi-Instance GPU) partitions allow multiple workflow steps to share a single physical GPU, reducing costs for workloads with low GPU utilization. Requires a MIG-enabled nodegroup on the cluster.
+
+These options have no effect when running locally or via Docker—they are only used by the Argo workflow system.
+
 <br/>
 
 

--- a/config/config-example.yml
+++ b/config/config-example.yml
@@ -68,6 +68,7 @@ calibrate_reflectance: # (Metahsape: calibrateReflectance)
 match_photos: # (Metashape: matchPhotos)
     enabled: True
     gpu_enabled: true # Optional. For Argo workflows: if true, run on GPU node; if false, run on CPU node. If omitted, defaults to true. Has no effect on local execution (Metashape auto-detects available hardware).
+    gpu_resource: "nvidia.com/gpu" # Optional. For Argo workflows on OFO cluster: GPU resource to request. Options: "nvidia.com/gpu" (full GPU, default), "nvidia.com/mig-1g.10gb", "nvidia.com/mig-2g.10gb", "nvidia.com/mig-3g.20gb" (MIG partitions). Requires MIG-enabled nodegroup. Has no effect on local execution. See: https://github.com/open-forest-observatory/ofo-argo
     downscale: 2 # How much to coarsen the photos when searching for tie points. Higher number for blurrier photos or when there are small surfaces that may move between photos (such as leaves). Accepts numbers 2^x (and zero) (https://www.agisoft.com/forum/index.php?topic=11697.0).
     keep_keypoints: True # Should keypoints from matching photos be stored in the project? Required if you later want to add more photos and align them to the previously aligned photos without redoing the original alignment.
     generic_preselection: True # When matching photos, use a much-coarsened version of each photo to narrow down the potential neighbors to pair? Works well if the photos have high altitude above the surface and high overlap (e.g. a 120m nadir 90/90 overlap mission), but doesn't work well for low-altitude and/or highly oblique photos (e.g. a 80m 25deg pitch 80/80 overlap mission)
@@ -111,6 +112,7 @@ export_cameras: # (Metashape: exportCameras)
 
 build_depth_maps: # (Metashape: buildDepthMaps)
     enabled: True
+    gpu_resource: "nvidia.com/gpu" # Optional. For Argo workflows on OFO cluster: GPU resource to request. Options: "nvidia.com/gpu" (full GPU, default), "nvidia.com/mig-1g.10gb", "nvidia.com/mig-2g.10gb", "nvidia.com/mig-3g.20gb" (MIG partitions). Requires MIG-enabled nodegroup. Has no effect on local execution. See: https://github.com/open-forest-observatory/ofo-argo
     downscale: 4 # How much to coarsen the photos when searching for matches to build the point cloud. For large photosets, values < 4 likely take prohibitively long. Accepts numbers 2^x (https://www.agisoft.com/forum/index.php?topic=11697.0).
     filter_mode: Metashape.ModerateFiltering # How to filter the depth map. Options are NoFiltering, MildFiltering, ModerateFiltering, AggressiveFiltering. Aggressive filtering removes detail and makes worse DEMs (at least for forest). NoFiltering takes very long. In trials, it never completed.
     reuse_depth: False # Purpose unknown.
@@ -134,6 +136,7 @@ classify_ground_points: # (Metashape: classifyGroundPoints) # classify points, I
 build_mesh:
     enabled: True
     gpu_enabled: true # Optional. For Argo workflows: if true, run on GPU node; if false, run on CPU node. If omitted, defaults to true. Has no effect on local execution (Metashape auto-detects available hardware).
+    gpu_resource: "nvidia.com/gpu" # Optional. For Argo workflows on OFO cluster: GPU resource to request. Options: "nvidia.com/gpu" (full GPU, default), "nvidia.com/mig-1g.10gb", "nvidia.com/mig-2g.10gb", "nvidia.com/mig-3g.20gb" (MIG partitions). Requires MIG-enabled nodegroup. Has no effect on local execution. See: https://github.com/open-forest-observatory/ofo-argo
     face_count: "Metashape.MediumFaceCount" # How many faces to use, Metashape.LowFaceCount, MediumFaceCount, HighFaceCount, CustomFaceCount
     face_count_custom: 100000 # Only used if custom number of faces set (above).
     export: True # Export the georeferenced mesh.


### PR DESCRIPTION
Adds optional `gpu_resource` parameter to GPU-capable steps (match_photos, build_depth_maps, build_mesh) that allows specifying MIG partitions instead of full GPUs when running via Argo on the OFO Kubernetes cluster.

Options:
- nvidia.com/gpu (full GPU, default)
- nvidia.com/mig-1g.10gb (1/7 compute, 10GB VRAM)
- nvidia.com/mig-2g.10gb (2/7 compute, 10GB VRAM)
- nvidia.com/mig-3g.20gb (3/7 compute, 20GB VRAM)

This has no effect on local or Docker execution - only used by the Argo workflow system for Kubernetes resource requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)