### PR TITLE
Provide option to set offset between mean altitude of two photo groups

### DIFF
--- a/config/config-example.yml
+++ b/config/config-example.yml
@@ -65,9 +65,12 @@ add_photos: # (Metashape: addPhotos)
   apply_paired_altitude_offset: False
   # The desired altitude offset (in meters) to obtain between the two groups of photos
   paired_altitude_offset: 0
-  # Which folders from the photo_path list correspond to the lower altitude photos
+  # The below two elements specify which folders of images are assigned to upper and lower groups
+  # when computing an altitiude adjustment. They should be in the same format as the photo_path
+  # element (e.g., ["/path/to/photo/folder1", "/path/to/photo/folder2"])
+  # Lower altitude photo folders
   lower_offset_folders: []
-  # Which folders from the photo_path list correspond to the upper altitude photos
+  # Upper altitude photos folders
   upper_offset_folders: []
 
 calibrate_reflectance: # (Metahsape: calibrateReflectance)

--- a/config/config-example.yml
+++ b/config/config-example.yml
@@ -58,6 +58,15 @@ add_photos: # (Metashape: addPhotos)
   #   Frame: default, uses radial distortion to handle lens distortion
   #   Spherical: expects image data to come in in the equirectangular format
   sensor_type: Metashape.Sensor.Type.Frame # Sets the camera type. Tested choices: Metashape.Sensor.Type.Frame, Metashape.Sensor.Type.Spherical
+  # These options only apply if you have data collected with two different altitude references
+  # (e.g. using barometric altitude with a time delay between collections) and you want to enforce
+  # a specific altitude offset between the two groups of photos.
+  # Apply the offset
+  apply_paired_altitude_offset: False
+  # Which folders from the photo_path list correspond to the lower altitude photos
+  lower_offset_folders: []
+  # Which folders from the photo_path list correspond to the upper altitude photos
+  upper_offset_folders: []
 
 calibrate_reflectance: # (Metahsape: calibrateReflectance)
     enabled: False

--- a/config/config-example.yml
+++ b/config/config-example.yml
@@ -61,8 +61,10 @@ add_photos: # (Metashape: addPhotos)
   # These options only apply if you have data collected with two different altitude references
   # (e.g. using barometric altitude with a time delay between collections) and you want to enforce
   # a specific altitude offset between the two groups of photos.
-  # Apply the offset
+  # Whether to apply the offset. If set to False, no paramters below apply.
   apply_paired_altitude_offset: False
+  # The desired altitude offset (in meters) to obtain between the two groups of photos
+  paired_altitude_offset: 0
   # Which folders from the photo_path list correspond to the lower altitude photos
   lower_offset_folders: []
   # Which folders from the photo_path list correspond to the upper altitude photos

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -988,21 +988,21 @@ class MetashapeWorkflow:
             for cam in self.doc.chunk.cameras
         ]
 
-        # The shift can't be applied if one of the groups has no cameras
-        if sum(in_lower_group) == 0 or sum(in_upper_group) == 0:
-            raise ValueError(
-                "Cannot apply paired altitude offset: no cameras found in one of the specified groups."
-            )
-
-        if sum(in_lower_group) + sum(in_upper_group) != len(self.doc.chunk.cameras):
-            print(
-                "Warning: Some cameras not in either offset group; they will not be adjusted."
-            )
-
         # Compute counts
         n_lower = sum(in_lower_group)
         n_upper = sum(in_upper_group)
         n_total = n_lower + n_upper
+
+        # The shift can't be applied if one of the groups has no cameras
+        if n_lower == 0 or n_upper == 0:
+            raise ValueError(
+                "Cannot apply paired altitude offset: no cameras found in one of the specified groups."
+            )
+
+        if n_lower + n_upper != len(self.doc.chunk.cameras):
+            print(
+                "Warning: Some cameras not in either offset group; they will not be adjusted."
+            )
 
         # Compute mean altitudes of current locations
         mean_lower = (

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -972,9 +972,13 @@ class MetashapeWorkflow:
     def apply_paired_altitude_offset(
         self, lower_offset_folders, upper_offset_folders, offset
     ):
-        # Compute the altitude for each camera
+        """
+        Shift altitudes of the two groups of cameras such that the difference in mean altitudes
+        is the desired "offset".
+        """
+        # Extract the altitude for each camera
         altitudes = [cam.reference.location[2] for cam in self.doc.chunk.cameras]
-        # Determine which cameras are in each group
+        # Determine which cameras are in each group based on their paths
         in_lower_group = [
             any(folder in cam.photo.path for folder in lower_offset_folders)
             for cam in self.doc.chunk.cameras
@@ -1013,10 +1017,13 @@ class MetashapeWorkflow:
         # Shift the groups to achieve the desired offsets, preserving the overall mean altitude
         # by shifting groups with more cameras less
         lower_adjustment = (current_offset - offset) * n_upper / n_total
+        # Note negative sign
         upper_adjustment = -(current_offset - offset) * n_lower / n_total
 
+        # Apply the computed adjustments to the relevant cameras
         for cam, in_lower in zip(self.doc.chunk.cameras, in_lower_group):
             if in_lower:
+                # It appears that these values cannot be updated in place, so we need to create a new Vector
                 cam.reference.location = Metashape.Vector(
                     [
                         cam.reference.location[0],


### PR DESCRIPTION
This allows the user to provide a desired offset between two groups of photos. Then, the altitude reference will be updated such that the desired offset is obtained between the means of the two groups of photos. The group with more photos is shifted proportionally less such that the mean altitude remains unchanged.

Note, there's not yet any error checking for nonexistent altitude values. @youngdjn do you think this is worth checking for? 