### PR TITLE
Add progress callbacks and heartbeat output monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ The wrapper forwards SIGTERM and SIGINT signals to the child Metashape process, 
 The license retry wrapper includes an output monitor that reduces console log volume during long-running Metashape steps while preserving full debuggability. This is especially useful in orchestrated environments (e.g., Argo/Kubernetes) where verbose Metashape output can overwhelm log storage.
 
 **Features:**
-- **Progress callbacks**: Metashape API calls report structured `[automate-metashape-progress] operation: X%` messages at configurable percentage intervals
-- **Heartbeat**: Periodic liveness messages showing timestamp, line count, elapsed time, and most recent Metashape output line
+- **Progress callbacks**: Metashape API calls report progress at configurable percentage intervals. In sparse mode, progress is folded into the periodic heartbeat line rather than printed separately. In full output mode, progress lines are printed immediately.
+- **Heartbeat**: Periodic liveness messages showing timestamp, output line count, elapsed time, current progress percentage, and most recent Metashape output line
 - **Full log file**: Every line of Metashape output is written to a log file on disk (as a sibling to `--output-path`), even when console output is sparse
 - **Error context buffer**: On failure, the last N lines of output are dumped to console for immediate debugging
 - **Full output mode**: Set `LOG_HEARTBEAT_INTERVAL=0` to print all lines to console (original behavior) while still getting progress callbacks, full log file, and error buffer
@@ -212,7 +212,7 @@ export PROGRESS_INTERVAL_PCT=10
 python {repo_path}/python/license_retry_wrapper.py --config-file config.yml --step build_depth_maps --output-path /data/output
 ```
 
-Console output will be ~20-30 lines per step instead of thousands, with progress milestones and periodic heartbeats. The full log is saved to `/data/metashape-build_depth_maps.log`.
+Console output will be ~10-20 lines per step instead of thousands, with progress included in periodic heartbeat lines. The full log is saved to `/data/metashape-build_depth_maps.log`.
 
 **Example with full output (original behavior):**
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ All command-line arguments are passed through to `metashape_workflow.py`.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `LICENSE_MAX_RETRIES` | `0` | Maximum retry attempts. `0` = unlimited (retry forever) |
+| `LICENSE_MAX_RETRIES` | `0` | Maximum retry attempts. `0` = no retries (fail immediately), `-1` = unlimited, `>0` = that many retries |
 | `LICENSE_RETRY_INTERVAL` | `300` | Seconds to wait between retry attempts |
 | `LICENSE_CHECK_LINES` | `20` | Number of output lines to monitor for license errors |
 
@@ -183,6 +183,43 @@ python {repo_path}/python/license_retry_wrapper.py --config-file config.yml
 **Signal Handling:**
 
 The wrapper forwards SIGTERM and SIGINT signals to the child Metashape process, ensuring graceful shutdown in containerized/orchestrated environments (e.g., Kubernetes pod termination).
+
+#### Output Monitoring and Heartbeat
+
+The license retry wrapper includes an output monitor that reduces console log volume during long-running Metashape steps while preserving full debuggability. This is especially useful in orchestrated environments (e.g., Argo/Kubernetes) where verbose Metashape output can overwhelm log storage.
+
+**Features:**
+- **Progress callbacks**: Metashape API calls report structured `[automate-metashape-progress] operation: X%` messages at configurable percentage intervals
+- **Heartbeat**: Periodic liveness messages showing timestamp, line count, elapsed time, and most recent Metashape output line
+- **Full log file**: Every line of Metashape output is written to a log file on disk (as a sibling to `--output-path`), even when console output is sparse
+- **Error context buffer**: On failure, the last N lines of output are dumped to console for immediate debugging
+- **Full output mode**: Set `LOG_HEARTBEAT_INTERVAL=0` to print all lines to console (original behavior) while still getting progress callbacks, full log file, and error buffer
+
+**Environment Variables:**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PROGRESS_INTERVAL_PCT` | `1` | Print progress every N percent (e.g., `10` prints at 10%, 20%, 30%...) |
+| `LOG_HEARTBEAT_INTERVAL` | `60` | Seconds between heartbeat status lines. `0` = full output mode (print all lines, no filtering) |
+| `LOG_BUFFER_SIZE` | `100` | Number of lines kept in circular buffer for error context dump on failure |
+| `LOG_OUTPUT_DIR` | _(unset)_ | Optional override for full log file directory. If not set, log is placed as a sibling to `--output-path` |
+
+**Example with sparse output (default):**
+
+```bash
+export LOG_HEARTBEAT_INTERVAL=60
+export PROGRESS_INTERVAL_PCT=10
+python {repo_path}/python/license_retry_wrapper.py --config-file config.yml --step build_depth_maps --output-path /data/output
+```
+
+Console output will be ~20-30 lines per step instead of thousands, with progress milestones and periodic heartbeats. The full log is saved to `/data/metashape-build_depth_maps.log`.
+
+**Example with full output (original behavior):**
+
+```bash
+export LOG_HEARTBEAT_INTERVAL=0
+python {repo_path}/python/license_retry_wrapper.py --config-file config.yml
+```
 
 <br/>
 
@@ -329,7 +366,7 @@ To use the wrapper instead of running `metashape_workflow.py` directly, override
 docker run -v </host/data/dir>:/data \
   -e AGISOFT_FLS=$AGISOFT_FLS \
   -e LICENSE_RETRY_INTERVAL=300 \
-  -e LICENSE_MAX_RETRIES=0 \
+  -e LICENSE_MAX_RETRIES=-1 \
   --gpus all \
   --entrypoint python3 \
   ghcr.io/open-forest-observatory/automate-metashape \
@@ -340,11 +377,17 @@ docker run -v </host/data/dir>:/data \
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `LICENSE_MAX_RETRIES` | `0` | Maximum retry attempts. `0` = unlimited (retry forever) |
+| `LICENSE_MAX_RETRIES` | `0` | Maximum retry attempts. `0` = no retries (fail immediately), `-1` = unlimited, `>0` = that many retries |
 | `LICENSE_RETRY_INTERVAL` | `300` | Seconds to wait between retry attempts |
 | `LICENSE_CHECK_LINES` | `20` | Number of output lines to monitor for license errors |
+| `PROGRESS_INTERVAL_PCT` | `1` | Print progress every N percent (e.g., `10` prints at 10%, 20%, 30%...) |
+| `LOG_HEARTBEAT_INTERVAL` | `60` | Seconds between heartbeat status lines. `0` = full output mode (print all lines) |
+| `LOG_BUFFER_SIZE` | `100` | Number of lines kept in circular buffer for error context dump on failure |
+| `LOG_OUTPUT_DIR` | _(unset)_ | Optional override for full log file directory |
 
 The wrapper monitors Metashape's startup output for license errors. If detected, it terminates the process immediately (before wasting compute time on processing that would fail at save), waits the specified interval, and retries. This is particularly useful in orchestrated environments like Kubernetes/Argo where multiple workflows may compete for floating licenses.
+
+The wrapper also includes an output monitor with progress callbacks, periodic heartbeat messages, error context buffering, and full log file output. See the [Output Monitoring and Heartbeat](#output-monitoring-and-heartbeat) section above for details.
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ The license retry wrapper includes an output monitor that reduces console log vo
 **Features:**
 - **Progress callbacks**: Metashape API calls report progress at configurable percentage intervals. In sparse mode, progress is folded into the periodic heartbeat line rather than printed separately. In full output mode, progress lines are printed immediately.
 - **Heartbeat**: Periodic liveness messages showing timestamp, output line count, elapsed time, current progress percentage, and most recent Metashape output line
-- **Full log file**: Every line of Metashape output is written to a log file on disk (as a sibling to `--output-path`), even when console output is sparse
+- **Full log file** (opt-in): When enabled via `LOG_OUTPUT=1`, every line of Metashape output is written to a log file on disk (as a sibling to `--output-path`), even when console output is sparse
 - **Error context buffer**: On failure, the last N lines of output are dumped to console for immediate debugging
-- **Full output mode**: Set `LOG_HEARTBEAT_INTERVAL=0` to print all lines to console (original behavior) while still getting progress callbacks, full log file, and error buffer
+- **Full output mode**: Set `LOG_HEARTBEAT_INTERVAL=0` to print all lines to console (original behavior) while still getting progress callbacks, optional log file, and error buffer
 
 **Environment Variables:**
 
@@ -202,6 +202,7 @@ The license retry wrapper includes an output monitor that reduces console log vo
 | `PROGRESS_INTERVAL_PCT` | `1` | Print progress every N percent (e.g., `10` prints at 10%, 20%, 30%...) |
 | `LOG_HEARTBEAT_INTERVAL` | `60` | Seconds between heartbeat status lines. `0` = full output mode (print all lines, no filtering) |
 | `LOG_BUFFER_SIZE` | `100` | Number of lines kept in circular buffer for error context dump on failure |
+| `LOG_OUTPUT` | _(off)_ | Write full output to a log file on disk. Set to `1`, `true`, or `yes` to enable |
 | `LOG_OUTPUT_DIR` | _(unset)_ | Optional override for full log file directory. If not set, log is placed as a sibling to `--output-path` |
 
 **Example with sparse output (default):**
@@ -212,7 +213,7 @@ export PROGRESS_INTERVAL_PCT=10
 python {repo_path}/python/license_retry_wrapper.py --config-file config.yml --step build_depth_maps --output-path /data/output
 ```
 
-Console output will be ~10-20 lines per step instead of thousands, with progress included in periodic heartbeat lines. The full log is saved to `/data/metashape-build_depth_maps.log`.
+Console output will be ~10-20 lines per step instead of thousands, with progress included in periodic heartbeat lines. If `LOG_OUTPUT=1` is set, the full log is saved to `/data/metashape-output-log_build_depth_maps.log`.
 
 **Example with full output (original behavior):**
 
@@ -383,11 +384,12 @@ docker run -v </host/data/dir>:/data \
 | `PROGRESS_INTERVAL_PCT` | `1` | Print progress every N percent (e.g., `10` prints at 10%, 20%, 30%...) |
 | `LOG_HEARTBEAT_INTERVAL` | `60` | Seconds between heartbeat status lines. `0` = full output mode (print all lines) |
 | `LOG_BUFFER_SIZE` | `100` | Number of lines kept in circular buffer for error context dump on failure |
+| `LOG_OUTPUT` | _(off)_ | Write full output to a log file on disk. Set to `1`, `true`, or `yes` to enable |
 | `LOG_OUTPUT_DIR` | _(unset)_ | Optional override for full log file directory |
 
 The wrapper monitors Metashape's startup output for license errors. If detected, it terminates the process immediately (before wasting compute time on processing that would fail at save), waits the specified interval, and retries. This is particularly useful in orchestrated environments like Kubernetes/Argo where multiple workflows may compete for floating licenses.
 
-The wrapper also includes an output monitor with progress callbacks, periodic heartbeat messages, error context buffering, and full log file output. See the [Output Monitoring and Heartbeat](#output-monitoring-and-heartbeat) section above for details.
+The wrapper also includes an output monitor with progress callbacks, periodic heartbeat messages, error context buffering, and optional full log file output (`LOG_OUTPUT=1`). See the [Output Monitoring and Heartbeat](#output-monitoring-and-heartbeat) section above for details.
 
 <br/>
 

--- a/python/license_retry_wrapper.py
+++ b/python/license_retry_wrapper.py
@@ -124,7 +124,7 @@ class OutputMonitor:
                 if "100%" in stripped:
                     print(f"[automate-metashape-heartbeat] {time.strftime('%H:%M:%S')} | {op_name}: completed")
             elif not any(line.startswith(prefix) for prefix in self.important_prefixes):
-                self.last_content_line = stripped[:100]  # Truncate to 100 chars
+                self.last_content_line = stripped[:200] + ("..." if len(stripped) > 200 else "")
 
             # Pass through important lines to console (except progress, which is folded into heartbeat)
             if any(line.startswith(prefix) for prefix in self.important_prefixes) and not line.startswith("[automate-metashape-progress]"):

--- a/python/license_retry_wrapper.py
+++ b/python/license_retry_wrapper.py
@@ -135,7 +135,7 @@ class OutputMonitor:
                 )
                 print(
                     f"[automate-metashape-heartbeat] {time.strftime('%H:%M:%S')} | "
-                    f"lines: {self.line_count} | "
+                    f"output lines: {self.line_count} | "
                     f"elapsed: {elapsed:.0f}s{progress_display}{last_line_display}"
                 )
                 self.last_heartbeat = now
@@ -155,11 +155,11 @@ class OutputMonitor:
         status = "SUCCESS" if exit_code == 0 else f"FAILED (exit code {exit_code})"
         print(
             f"[automate-metashape-monitor] {status} | "
-            f"total lines: {self.line_count} | "
+            f"total output lines: {self.line_count} | "
             f"elapsed: {elapsed:.0f}s"
         )
         if self.log_file:
-            print(f"[automate-metashape-monitor] Full log saved to: {self.log_file.name}")
+            print(f"[automate-metashape-monitor] Full metashape output log saved to: {self.log_file.name}")
 
     def close(self):
         """Clean up resources."""

--- a/python/license_retry_wrapper.py
+++ b/python/license_retry_wrapper.py
@@ -60,10 +60,10 @@ class OutputMonitor:
 
         # Important line prefixes to always pass through to console (in sparse mode)
         self.important_prefixes = (
-            "[progress]",
-            "[license-wrapper]",
-            "[monitor]",
-            "[heartbeat]",
+            "[automate-metashape-progress]",
+            "[automate-metashape-license-wrapper]",
+            "[automate-metashape-monitor]",
+            "[automate-metashape-heartbeat]",
         )
 
         # Open full log file if path provided
@@ -72,10 +72,10 @@ class OutputMonitor:
             if log_dir:
                 os.makedirs(log_dir, exist_ok=True)
             self.log_file = open(log_file_path, "w", buffering=1)  # Line buffered
-            print(f"[monitor] Full log: {log_file_path}")
+            print(f"[automate-metashape-monitor] Full log: {log_file_path}")
 
         if self.full_output_mode:
-            print("[monitor] Full output mode enabled (LOG_HEARTBEAT_INTERVAL=0)")
+            print("[automate-metashape-monitor] Full output mode enabled (LOG_HEARTBEAT_INTERVAL=0)")
 
     def process_line(self, line):
         """
@@ -123,7 +123,7 @@ class OutputMonitor:
                     else ""
                 )
                 print(
-                    f"[heartbeat] {time.strftime('%H:%M:%S')} | "
+                    f"[automate-metashape-heartbeat] {time.strftime('%H:%M:%S')} | "
                     f"lines: {self.line_count} | "
                     f"elapsed: {elapsed:.0f}s{last_line_display}"
                 )
@@ -133,22 +133,22 @@ class OutputMonitor:
 
     def dump_buffer(self):
         """Dump circular buffer contents to console (for error context)."""
-        print(f"\n[monitor] === Last {len(self.buffer)} lines before error ===")
+        print(f"\n[automate-metashape-monitor] === Last {len(self.buffer)} lines before error ===")
         for line in self.buffer:
             print(line, end="")
-        print("[monitor] === End error context ===\n")
+        print("[automate-metashape-monitor] === End error context ===\n")
 
     def print_summary(self, exit_code):
         """Print final summary of processing."""
         elapsed = time.time() - self.start_time
         status = "SUCCESS" if exit_code == 0 else f"FAILED (exit code {exit_code})"
         print(
-            f"[monitor] {status} | "
+            f"[automate-metashape-monitor] {status} | "
             f"total lines: {self.line_count} | "
             f"elapsed: {elapsed:.0f}s"
         )
         if self.log_file:
-            print(f"[monitor] Full log saved to: {self.log_file.name}")
+            print(f"[automate-metashape-monitor] Full log saved to: {self.log_file.name}")
 
     def close(self):
         """Clean up resources."""
@@ -210,7 +210,7 @@ def _signal_handler(signum, frame):
     global _child_process
     if _child_process is not None and _child_process.poll() is None:
         sig_name = signal.Signals(signum).name
-        print(f"[license-wrapper] Received {sig_name}, forwarding to child process...")
+        print(f"[automate-metashape-license-wrapper] Received {sig_name}, forwarding to child process...")
         _child_process.send_signal(signum)
 
 
@@ -242,7 +242,7 @@ def run_with_license_retry():
     while True:
         attempt += 1
         monitor.reset()
-        print(f"[license-wrapper] Starting Metashape workflow (attempt {attempt})...")
+        print(f"[automate-metashape-license-wrapper] Starting Metashape workflow (attempt {attempt})...")
 
         _child_process = subprocess.Popen(
             cmd,
@@ -281,7 +281,7 @@ def run_with_license_retry():
                 line_count += 1
                 if line_count >= license_check_lines:
                     print(
-                        "[license-wrapper] License check passed, proceeding with workflow..."
+                        "[automate-metashape-license-wrapper] License check passed, proceeding with workflow..."
                     )
             else:
                 # Post-license-check: use monitor for selective output
@@ -293,16 +293,16 @@ def run_with_license_retry():
             # max_retries: 0 = no retries (fail immediately), -1 = unlimited, >0 = that many retries
             if max_retries == 0:
                 print(
-                    "[license-wrapper] No license available and retries disabled (LICENSE_MAX_RETRIES=0)"
+                    "[automate-metashape-license-wrapper] No license available and retries disabled (LICENSE_MAX_RETRIES=0)"
                 )
                 monitor.close()
                 sys.exit(1)
             if max_retries > 0 and attempt > max_retries:
-                print(f"[license-wrapper] Max retries ({max_retries}) exceeded")
+                print(f"[automate-metashape-license-wrapper] Max retries ({max_retries}) exceeded")
                 monitor.close()
                 sys.exit(1)
             print(
-                f"[license-wrapper] No license available. Waiting {retry_interval}s before retry..."
+                f"[automate-metashape-license-wrapper] No license available. Waiting {retry_interval}s before retry..."
             )
             time.sleep(retry_interval)
             continue

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -322,7 +322,7 @@ class MetashapeWorkflow:
             # Print when crossing interval threshold or reaching 100%
             if pct >= last_report[0] + interval or pct >= 100:
                 print(
-                    f"[progress] {operation_name}: {pct}%",
+                    f"[automate-metashape-progress] {operation_name}: {pct}%",
                     file=sys.stderr,
                     flush=True,
                 )

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -320,13 +320,18 @@ class MetashapeWorkflow:
             """Progress callback: receives 0-100 float from Metashape."""
             pct = int(progress)
             # Print when crossing interval threshold or reaching 100%
-            if pct >= last_report[0] + interval or pct >= 100:
+            if pct >= last_report[0] + interval or (
+                pct >= 100 and last_report[0] < 100
+            ):
+                # Update state before print() to avoid race condition:
+                # print() releases the GIL, allowing other Metashape threads
+                # to pass the check before last_report is updated.
+                last_report[0] = pct
                 print(
                     f"[automate-metashape-progress] {operation_name}: {pct}%",
                     file=sys.stderr,
                     flush=True,
                 )
-                last_report[0] = pct
 
         return callback
 


### PR DESCRIPTION
### Summary
- Add Metashape API progress callbacks that print structured `[automate-metashape-progress] operation: X%` messages at configurable intervals during long-running steps
- Add `OutputMonitor` class to the license retry wrapper that reduces console log volume while preserving debuggability: selective pass-through of important lines, periodic heartbeat messages, circular buffer for error context dump, and full log file on shared volume
- In sparse mode (default), console output drops from thousands of lines to ~20-30 per step; setting `LOG_HEARTBEAT_INTERVAL=0` restores full output

See added documentation for details