### PR TITLE
Ensure correct sensor per group

### DIFF
--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -943,23 +943,31 @@ class MetashapeWorkflow:
 
         if self.cfg["add_photos"]["separate_calibration_per_path"]:
             # Assign a different (new) sensor (i.e. independent calibration) to each group of photos
-            for grp in self.doc.chunk.camera_groups:
 
+            # Record the number of initial (distinct) sensors, since these will be removed at the end
+            n_initial_sensors = len(self.doc.chunk.sensors)
+
+            # Add one sensor per group
+            for grp in self.doc.chunk.camera_groups:
                 # Get the template for the sensor from the first photo in the group
                 for cam in self.doc.chunk.cameras:
                     if cam.group == grp:
                         sensor = cam.sensor
                         break
 
-                self.doc.chunk.addSensor(self.doc.chunk.cameras[0].sensor)
-                sensor = self.doc.chunk.sensors[-1]
+                # Add the representative sensor to the list of sensors
+                # Note, each sensor in this list appears to have a difference memory address, despite
+                # never having performed an explicit copy operation.
+                self.doc.chunk.addSensor(sensor)
 
+                # Assign the sensor to all cameras in the group
                 for cam in self.doc.chunk.cameras:
                     if cam.group == grp:
                         cam.sensor = sensor
 
-            # Remove the first (deafult) sensor, which should no longer be assigned to any photos
-            self.doc.chunk.remove(self.doc.chunk.sensors[0])
+            # Remove the first (default) sensor(s), which should no longer be assigned to any photos
+            for _ in range(n_initial_sensors):
+                self.doc.chunk.remove(self.doc.chunk.sensors[0])
 
         ## If specified, change the accuracy of the cameras to match the RTK flag (RTK fix if flag = 50, otherwise no fix
         if self.cfg["add_photos"]["use_rtk"]:

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -960,6 +960,9 @@ class MetashapeWorkflow:
                 # never having performed an explicit copy operation.
                 self.doc.chunk.addSensor(sensor)
 
+                # Query the sensor from the list to make sure it's the same object as in the list
+                sensor = self.doc.chunk.sensors[-1]
+
                 # Assign the sensor to all cameras in the group
                 for cam in self.doc.chunk.cameras:
                     if cam.group == grp:


### PR DESCRIPTION
This fixes an issue I identified where the same sensor type was applied to all groups, despite actually having different sensors. This is because the first overall sensor was being added to the sensor list, rather than the selected sensor for the group. I tested this on the problematic dataset `000136_000133` and it correctly shows two different sensors in the GUI and runs keypoint detection.